### PR TITLE
Reduce the amount of data that we send with every Espresso block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9986,6 +9986,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "async-lock 3.4.1",
+ "bitvec",
  "clap 4.5.51",
  "cld",
  "committable",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ alloy = { version = "1.0", features = [
     "node-bindings",
 ] }
 async-lock = "3.0"
+bitvec = "1"
 clap = { version = "4.4", features = ["derive", "env"] }
 cld = "0.5"
 committable = { git = "https://github.com/EspressoSystems/commit.git", features = [

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -105,8 +105,8 @@ pub struct ActiveNodeSetEntry {
 /// A general participation percentage change for a node.
 #[derive(Clone, Copy, Debug, PartialEq, Deserialize, Serialize)]
 pub struct ParticipationChange {
-    /// The address of the node whose participation percentage is changing.
-    pub address: Address,
+    /// The index in the active node list of the node whose participation percentage is changing.
+    pub node: usize,
 
     /// The new participation ratio.
     pub ratio: Ratio,


### PR DESCRIPTION
* For leader participation changes, replace `Address` (about 40
      characters in JSON) with index into active node list (1-2
      characters)
* Combine events that are always sent with each new block (leader
      participation changes and voter participation changes)
* Instead of sending the address and participation rate for each
      node whose voter participation rate is changing (which will
      always be every active node), send a bitmap of just the nodes
      who voted. The client can then compute the new participation
      rates for every node.