### PR TITLE
fix(l1): handle WithdrawalClaimed for legacy V1 undelegations

### DIFF
--- a/src/input/l1.rs
+++ b/src/input/l1.rs
@@ -909,16 +909,53 @@ impl Snapshot {
                         )
                     });
 
-                    if !wallet.pending_undelegations.contains_key(&ev.validator) {
+                    // For V2 undelegations (ID >= 1), the pending undelegation must exist
+                    // for the exact validator.
+                    //
+                    // For legacy V1 undelegations (ID == 0), the pending undelegation for
+                    // this validator may have been consumed by a V1 Withdrawal event that
+                    // matched by amount instead of by validator. In that case, find any
+                    // pending undelegation with the same amount to reconcile the state.
+                    // The linear scan is acceptable since this only applies to legacy V1
+                    // undelegations on the Decaf testnet.
+                    let node = if wallet.pending_undelegations.contains_key(&ev.validator) {
+                        ev.validator
+                    } else if ev.undelegationId == 0 {
+                        if let Some((_, pending)) = wallet
+                            .pending_undelegations
+                            .iter()
+                            .find(|(_, p)| p.amount == ev.amount)
+                        {
+                            tracing::warn!(
+                                delegator = %ev.delegator,
+                                validator = %ev.validator,
+                                matched_node = %pending.node,
+                                amount = %ev.amount,
+                                "WithdrawalClaimed for legacy V1 undelegation matched \
+                                 different pending undelegation by amount"
+                            );
+                            pending.node
+                        } else {
+                            tracing::warn!(
+                                delegator = %ev.delegator,
+                                validator = %ev.validator,
+                                amount = %ev.amount,
+                                "ignoring WithdrawalClaimed for legacy V1 undelegation \
+                                 with no matching pending undelegation"
+                            );
+                            return (vec![], vec![]);
+                        }
+                    } else {
                         panic!(
-                            "got WithdrawalClaimed but no pending undelegation for delegator {} validator {} amount {}",
+                            "got WithdrawalClaimed but no pending undelegation for \
+                             delegator {} validator {} amount {}",
                             ev.delegator, ev.validator, ev.amount
                         );
-                    }
+                    };
 
                     let withdrawal = Withdrawal {
                         delegator: ev.delegator,
-                        node: ev.validator,
+                        node,
                         amount: ev.amount,
                     };
                     let wallet_diff = WalletDiff::UndelegationWithdrawal(withdrawal);
@@ -1142,7 +1179,7 @@ impl Wallet {
                     // ONLY ON DECAF this is ok. The legacy withdrawal event does not contain
                     // enough information to accurately correlate every withdrawal to the correct
                     // pending withdrawal. Thus, it is possible that a previous withdrawal that was
-                    // meant to clear a pending undelegation from this node got misinterpeted as
+                    // meant to clear a pending undelegation from this node got misinterpreted as
                     // clearing a different undelegation, leaving a stale undelegation to this node
                     // in the wallet state. Now, having overwritten this stale undelegation with a
                     // fresh one, our state should once again match the contract state.

--- a/src/input/l1.rs
+++ b/src/input/l1.rs
@@ -902,6 +902,21 @@ impl Snapshot {
                     );
                 }
                 StakeTableV2Events::WithdrawalClaimed(ev) => {
+                    // V2 undelegation IDs start from 1. ID 0 is reserved for legacy V1
+                    // undelegations whose claims are already handled by the V1 Withdrawal
+                    // event. Skip to avoid double-counting. May happen on Decaf, must
+                    // not happen on mainnet.
+                    if ev.undelegationId == 0 {
+                        tracing::warn!(
+                            delegator = %ev.delegator,
+                            validator = %ev.validator,
+                            amount = %ev.amount,
+                            "ignoring WithdrawalClaimed for legacy V1 undelegation. \
+                             May happen on Decaf, must not happen on mainnet."
+                        );
+                        return (vec![], vec![]);
+                    }
+
                     let wallet = self.wallets.get(&ev.delegator).unwrap_or_else(|| {
                         panic!(
                             "got WithdrawalClaimed event for non existent wallet: {}",
@@ -909,49 +924,15 @@ impl Snapshot {
                         )
                     });
 
-                    // For V2 undelegations (ID >= 1), the pending undelegation must exist
-                    // for the exact validator.
-                    //
-                    // For legacy V1 undelegations (ID == 0), the pending undelegation for
-                    // this validator may have been consumed by a V1 Withdrawal event that
-                    // matched by amount instead of by validator. In that case, find any
-                    // pending undelegation with the same amount to reconcile the state.
-                    // The linear scan is acceptable since this only applies to legacy V1
-                    // undelegations on the Decaf testnet.
-                    let node = if wallet.pending_undelegations.contains_key(&ev.validator) {
-                        ev.validator
-                    } else if ev.undelegationId == 0 {
-                        if let Some((_, pending)) = wallet
-                            .pending_undelegations
-                            .iter()
-                            .find(|(_, p)| p.amount == ev.amount)
-                        {
-                            tracing::warn!(
-                                delegator = %ev.delegator,
-                                validator = %ev.validator,
-                                matched_node = %pending.node,
-                                amount = %ev.amount,
-                                "WithdrawalClaimed for legacy V1 undelegation matched \
-                                 different pending undelegation by amount"
-                            );
-                            pending.node
-                        } else {
-                            tracing::warn!(
-                                delegator = %ev.delegator,
-                                validator = %ev.validator,
-                                amount = %ev.amount,
-                                "ignoring WithdrawalClaimed for legacy V1 undelegation \
-                                 with no matching pending undelegation"
-                            );
-                            return (vec![], vec![]);
-                        }
-                    } else {
+                    if !wallet.pending_undelegations.contains_key(&ev.validator) {
                         panic!(
                             "got WithdrawalClaimed but no pending undelegation for \
                              delegator {} validator {} amount {}",
                             ev.delegator, ev.validator, ev.amount
                         );
-                    };
+                    }
+
+                    let node = ev.validator;
 
                     let withdrawal = Withdrawal {
                         delegator: ev.delegator,
@@ -2386,14 +2367,13 @@ mod test {
 
     /// Regression test for the Decaf testnet crash.
     ///
-    /// The V1 `Withdrawal(account, amount)` event has no validator address, so the
-    /// service matches pending undelegations by amount. When a delegator has multiple
-    /// pending undelegations with the same amount to different validators, the V1
-    /// `Withdrawal` may consume the wrong one. Later, the V2 contract emits
-    /// `WithdrawalClaimed` with `undelegationId=0` for the undelegation that was
-    /// actually claimed, but the service already cleared it (or a different one with
-    /// the same amount). The `WithdrawalClaimed` handler falls back to clearing any
-    /// pending undelegation with the matching amount, reconciling the state.
+    /// Each undelegation is claimed via either a V1 `Withdrawal` or a V2
+    /// `WithdrawalClaimed`, never both. The V1 `Withdrawal(account, amount)` has no
+    /// validator address, so the service matches pending undelegations by amount.
+    /// When multiple pending undelegations have the same amount, it may consume the
+    /// wrong one. The later `WithdrawalClaimed(undelegationId=0)` for a different
+    /// undelegation is skipped since it is a legacy V1 claim. This may leave stale
+    /// pending undelegations on Decaf, which is acceptable for a testnet.
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_legacy_v1_withdrawal_claimed_is_ignored() {
         let delegator = Address::random();
@@ -2476,10 +2456,9 @@ mod test {
         let wallet = block.state.wallets.get(&delegator).unwrap();
         assert_eq!(wallet.pending_undelegations.len(), num_v2_claims);
 
-        // Claim the V2 validators via V2 WithdrawalClaimed. Their pending
-        // undelegations may or may not still exist (V1 Withdrawals above may have
-        // consumed them by amount). The handler falls back to matching by amount
-        // when the exact validator is not found. Must not panic.
+        // V2 WithdrawalClaimed with undelegationId=0 for the V2 validators. These are
+        // legacy claims that get skipped (the V1 Withdrawal already handled the actual
+        // withdrawal). Must not panic.
         for (addr, _) in &v2_validators {
             block = block
                 .next(
@@ -2497,9 +2476,12 @@ mod test {
             block_num += 1;
         }
 
-        // All undelegations accounted for.
+        // The V2 WithdrawalClaimed events were skipped (undelegationId=0). The V1
+        // Withdrawals cleared num_v1_claims pending undelegations, so num_v2_claims
+        // remain (though which validators they belong to is non-deterministic due to
+        // amount-matching).
         let wallet = block.state.wallets.get(&delegator).unwrap();
-        assert_eq!(wallet.pending_undelegations.len(), 0);
+        assert_eq!(wallet.pending_undelegations.len(), num_v2_claims);
         assert_eq!(wallet.pending_exits.len(), 0);
     }
 

--- a/src/input/l1.rs
+++ b/src/input/l1.rs
@@ -1353,7 +1353,7 @@ mod test {
     use espresso_types::{RegisteredValidatorMap, StakeTableState, v0_3::StakeTableEvent};
     use hotshot_contract_adapter::sol_types::StakeTableV2::{
         Delegated, ExitEscrowPeriodUpdated, MetadataUriUpdated, Undelegated, ValidatorExit,
-        ValidatorRegisteredV2, Withdrawal,
+        ValidatorRegisteredV2, Withdrawal, WithdrawalClaimed,
     };
     use pretty_assertions::assert_eq;
     use reqwest::Url;
@@ -2343,6 +2343,125 @@ mod test {
 
         let wallet = block5.state.wallets.get(&delegator).unwrap();
         assert_eq!(wallet.nodes.len(), 0);
+        assert_eq!(wallet.pending_undelegations.len(), 0);
+        assert_eq!(wallet.pending_exits.len(), 0);
+    }
+
+    /// Regression test for the Decaf testnet crash.
+    ///
+    /// The V1 `Withdrawal(account, amount)` event has no validator address, so the
+    /// service matches pending undelegations by amount. When a delegator has multiple
+    /// pending undelegations with the same amount to different validators, the V1
+    /// `Withdrawal` may consume the wrong one. Later, the V2 contract emits
+    /// `WithdrawalClaimed` with `undelegationId=0` for the undelegation that was
+    /// actually claimed, but the service already cleared it (or a different one with
+    /// the same amount). The `WithdrawalClaimed` handler falls back to clearing any
+    /// pending undelegation with the matching amount, reconciling the state.
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_legacy_v1_withdrawal_claimed_is_ignored() {
+        let delegator = Address::random();
+        let amount = U256::from(900);
+        let num_v1_claims = 5;
+        let num_v2_claims = 5;
+
+        // Validators whose undelegations will be claimed via V1 Withdrawal.
+        let v1_validators: Vec<_> = (0..num_v1_claims)
+            .map(|_| {
+                let reg = validator_registered_event(rand::thread_rng());
+                let addr = reg.account;
+                (addr, reg)
+            })
+            .collect();
+
+        // Validators whose undelegations will be claimed via V2 WithdrawalClaimed.
+        let v2_validators: Vec<_> = (0..num_v2_claims)
+            .map(|_| {
+                let reg = validator_registered_event(rand::thread_rng());
+                let addr = reg.account;
+                (addr, reg)
+            })
+            .collect();
+
+        // Block 1: Register all validators, delegate the same amount to each.
+        let mut events = Vec::new();
+        for (_, reg) in v1_validators.iter().chain(v2_validators.iter()) {
+            events.push(StakeTableV2Events::ValidatorRegisteredV2(reg.clone()));
+        }
+        for (addr, _) in v1_validators.iter().chain(v2_validators.iter()) {
+            events.push(StakeTableV2Events::Delegated(Delegated {
+                delegator,
+                validator: *addr,
+                amount,
+            }));
+        }
+        let mut block = test_events(&NoMetadata, events).await;
+
+        // Undelegate from every validator.
+        let mut block_num = 2u64;
+        for (addr, _) in v1_validators.iter().chain(v2_validators.iter()) {
+            block = block
+                .next(
+                    &NoMetadata,
+                    &BlockInput::empty(block_num).with_event(StakeTableV2Events::Undelegated(
+                        Undelegated {
+                            delegator,
+                            validator: *addr,
+                            amount,
+                        },
+                    )),
+                )
+                .await;
+            block_num += 1;
+        }
+
+        let total = num_v1_claims + num_v2_claims;
+        let wallet = block.state.wallets.get(&delegator).unwrap();
+        assert_eq!(wallet.pending_undelegations.len(), total);
+
+        // Claim the V1 validators via V1 Withdrawal. Each matches by amount (no
+        // validator address), so may consume a V2 validator's pending undelegation
+        // instead of the intended one.
+        for _ in 0..num_v1_claims {
+            block = block
+                .next(
+                    &NoMetadata,
+                    &BlockInput::empty(block_num).with_event(StakeTableV2Events::Withdrawal(
+                        Withdrawal {
+                            account: delegator,
+                            amount,
+                        },
+                    )),
+                )
+                .await;
+            block_num += 1;
+        }
+
+        let wallet = block.state.wallets.get(&delegator).unwrap();
+        assert_eq!(wallet.pending_undelegations.len(), num_v2_claims);
+
+        // Claim the V2 validators via V2 WithdrawalClaimed. Their pending
+        // undelegations may or may not still exist (V1 Withdrawals above may have
+        // consumed them by amount). The handler falls back to matching by amount
+        // when the exact validator is not found. Must not panic.
+        for (addr, _) in &v2_validators {
+            block = block
+                .next(
+                    &NoMetadata,
+                    &BlockInput::empty(block_num).with_event(
+                        StakeTableV2Events::WithdrawalClaimed(WithdrawalClaimed {
+                            delegator,
+                            validator: *addr,
+                            undelegationId: 0,
+                            amount,
+                        }),
+                    ),
+                )
+                .await;
+            block_num += 1;
+        }
+
+        // All undelegations accounted for.
+        let wallet = block.state.wallets.get(&delegator).unwrap();
         assert_eq!(wallet.pending_undelegations.len(), 0);
         assert_eq!(wallet.pending_exits.len(), 0);
     }

--- a/src/input/l1.rs
+++ b/src/input/l1.rs
@@ -2366,17 +2366,16 @@ mod test {
     }
 
     /// Regression test for the Decaf testnet crash: the service panicked on
-    /// `WithdrawalClaimed(undelegationId=0)` because it expected a matching pending
-    /// undelegation that had already been consumed by a V1 `Withdrawal` for an
-    /// undelegation by the same delegator and amount from a different validator.
+    /// `WithdrawalClaimed(undelegationId=0)` because it expected a matching pending undelegation
+    /// that had already been consumed by a V1 `Withdrawal` for an undelegation by the same
+    /// delegator and amount from a different validator.
     ///
-    /// Each undelegation is claimed via either a V1 `Withdrawal` or a V2
-    /// `WithdrawalClaimed`, never both. The V1 `Withdrawal(account, amount)` has no
-    /// validator address, so the service matches pending undelegations by amount.
-    /// When multiple pending undelegations have the same amount, it may consume the
-    /// wrong one. The `WithdrawalClaimed(undelegationId=0)` is now skipped since the
-    /// V1 `Withdrawal` already handled the claim. This may leave stale pending
-    /// undelegations on Decaf, which is acceptable for a testnet.
+    /// Each undelegation is claimed via either a V1 `Withdrawal` or a V2 `WithdrawalClaimed`, never
+    /// both. The V1 `Withdrawal(account, amount)` has no validator address, so the service matches
+    /// pending undelegations by amount. When multiple pending undelegations have the same amount,
+    /// it may consume the wrong one. The `WithdrawalClaimed(undelegationId=0)` are now skipped
+    /// because the withdrawal from this validator may have been "accidentally" consumed by the
+    /// amount matching logic.
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_legacy_v1_withdrawal_claimed_is_ignored() {
         let delegator = Address::random();
@@ -2459,9 +2458,9 @@ mod test {
         let wallet = block.state.wallets.get(&delegator).unwrap();
         assert_eq!(wallet.pending_undelegations.len(), num_v2_claims);
 
-        // V2 WithdrawalClaimed with undelegationId=0 for the V2 validators. These are
-        // legacy claims that get skipped (the V1 Withdrawal already handled the actual
-        // withdrawal). Must not panic.
+        // WithdrawalClaimed with undelegationId=0 for each V2 validator. These are
+        // skipped because the V1 Withdrawal amount-matching may have already consumed
+        // this validator's pending undelegation. Must not panic.
         for (addr, _) in &v2_validators {
             block = block
                 .next(
@@ -2479,10 +2478,9 @@ mod test {
             block_num += 1;
         }
 
-        // The V2 WithdrawalClaimed events were skipped (undelegationId=0). The V1
-        // Withdrawals cleared num_v1_claims pending undelegations, so num_v2_claims
-        // remain (though which validators they belong to is non-deterministic due to
-        // amount-matching).
+        // The WithdrawalClaimed events were skipped (undelegationId=0). The V1
+        // Withdrawals consumed num_v1_claims pending undelegations by amount-matching,
+        // so num_v2_claims remain (which validators they belong to is non-deterministic).
         let wallet = block.state.wallets.get(&delegator).unwrap();
         assert_eq!(wallet.pending_undelegations.len(), num_v2_claims);
         assert_eq!(wallet.pending_exits.len(), 0);

--- a/src/input/l1.rs
+++ b/src/input/l1.rs
@@ -2365,15 +2365,18 @@ mod test {
         assert_eq!(wallet.pending_exits.len(), 0);
     }
 
-    /// Regression test for the Decaf testnet crash.
+    /// Regression test for the Decaf testnet crash: the service panicked on
+    /// `WithdrawalClaimed(undelegationId=0)` because it expected a matching pending
+    /// undelegation that had already been consumed by a V1 `Withdrawal` for an
+    /// undelegation by the same delegator and amount from a different validator.
     ///
     /// Each undelegation is claimed via either a V1 `Withdrawal` or a V2
     /// `WithdrawalClaimed`, never both. The V1 `Withdrawal(account, amount)` has no
     /// validator address, so the service matches pending undelegations by amount.
     /// When multiple pending undelegations have the same amount, it may consume the
-    /// wrong one. The later `WithdrawalClaimed(undelegationId=0)` for a different
-    /// undelegation is skipped since it is a legacy V1 claim. This may leave stale
-    /// pending undelegations on Decaf, which is acceptable for a testnet.
+    /// wrong one. The `WithdrawalClaimed(undelegationId=0)` is now skipped since the
+    /// V1 `Withdrawal` already handled the claim. This may leave stale pending
+    /// undelegations on Decaf, which is acceptable for a testnet.
     #[test_log::test(tokio::test(flavor = "multi_thread"))]
     async fn test_legacy_v1_withdrawal_claimed_is_ignored() {
         let delegator = Address::random();

--- a/src/input/l1.rs
+++ b/src/input/l1.rs
@@ -2383,8 +2383,8 @@ mod test {
         let num_v1_claims = 5;
         let num_v2_claims = 5;
 
-        // Validators whose undelegations will be claimed via V1 Withdrawal.
-        let v1_validators: Vec<_> = (0..num_v1_claims)
+        // Validators whose undelegations will be claimed via Withdrawal event.
+        let claim_v1_vals: Vec<_> = (0..num_v1_claims)
             .map(|_| {
                 let reg = validator_registered_event(rand::thread_rng());
                 let addr = reg.account;
@@ -2392,8 +2392,8 @@ mod test {
             })
             .collect();
 
-        // Validators whose undelegations will be claimed via V2 WithdrawalClaimed.
-        let v2_validators: Vec<_> = (0..num_v2_claims)
+        // Validators whose undelegations will be claimed via WithdrawalClaimed event.
+        let claim_v2_vals: Vec<_> = (0..num_v2_claims)
             .map(|_| {
                 let reg = validator_registered_event(rand::thread_rng());
                 let addr = reg.account;
@@ -2403,10 +2403,10 @@ mod test {
 
         // Block 1: Register all validators, delegate the same amount to each.
         let mut events = Vec::new();
-        for (_, reg) in v1_validators.iter().chain(v2_validators.iter()) {
+        for (_, reg) in claim_v1_vals.iter().chain(claim_v2_vals.iter()) {
             events.push(StakeTableV2Events::ValidatorRegisteredV2(reg.clone()));
         }
-        for (addr, _) in v1_validators.iter().chain(v2_validators.iter()) {
+        for (addr, _) in claim_v1_vals.iter().chain(claim_v2_vals.iter()) {
             events.push(StakeTableV2Events::Delegated(Delegated {
                 delegator,
                 validator: *addr,
@@ -2417,7 +2417,7 @@ mod test {
 
         // Undelegate from every validator.
         let mut block_num = 2u64;
-        for (addr, _) in v1_validators.iter().chain(v2_validators.iter()) {
+        for (addr, _) in claim_v1_vals.iter().chain(claim_v2_vals.iter()) {
             block = block
                 .next(
                     &NoMetadata,
@@ -2437,9 +2437,9 @@ mod test {
         let wallet = block.state.wallets.get(&delegator).unwrap();
         assert_eq!(wallet.pending_undelegations.len(), total);
 
-        // Claim the V1 validators via V1 Withdrawal. Each matches by amount (no
-        // validator address), so may consume a V2 validator's pending undelegation
-        // instead of the intended one.
+        // Claim via Withdrawal events. Each matches by amount (no validator address),
+        // so may consume another validator's pending undelegation instead of the
+        // intended one.
         for _ in 0..num_v1_claims {
             block = block
                 .next(
@@ -2458,10 +2458,10 @@ mod test {
         let wallet = block.state.wallets.get(&delegator).unwrap();
         assert_eq!(wallet.pending_undelegations.len(), num_v2_claims);
 
-        // WithdrawalClaimed with undelegationId=0 for each V2 validator. These are
-        // skipped because the V1 Withdrawal amount-matching may have already consumed
+        // WithdrawalClaimed with undelegationId=0 for each remaining validator. These
+        // are skipped because the Withdrawal amount-matching may have already consumed
         // this validator's pending undelegation. Must not panic.
-        for (addr, _) in &v2_validators {
+        for (addr, _) in &claim_v2_vals {
             block = block
                 .next(
                     &NoMetadata,
@@ -2478,8 +2478,8 @@ mod test {
             block_num += 1;
         }
 
-        // The WithdrawalClaimed events were skipped (undelegationId=0). The V1
-        // Withdrawals consumed num_v1_claims pending undelegations by amount-matching,
+        // The WithdrawalClaimed events were skipped (undelegationId=0). The Withdrawal
+        // events consumed num_v1_claims pending undelegations by amount-matching,
         // so num_v2_claims remain (which validators they belong to is non-deterministic).
         let wallet = block.state.wallets.get(&delegator).unwrap();
         assert_eq!(wallet.pending_undelegations.len(), num_v2_claims);

--- a/src/input/l1/rpc_catchup.rs
+++ b/src/input/l1/rpc_catchup.rs
@@ -1,12 +1,13 @@
 //! L1 catchup based on a JSON-RPC provider.
 
-use std::{cmp::min, collections::BTreeMap};
+use std::{cmp::min, collections::BTreeMap, time::Duration};
 
 use alloy::{
     eips::BlockId,
     providers::{Provider, RootProvider},
     rpc::types::Filter,
 };
+use tokio::time::sleep;
 
 use crate::{
     Error, Result,
@@ -21,6 +22,7 @@ pub struct RpcCatchup {
     stake_table_addr: Address,
     reward_addr: Address,
     chunk_size: u64,
+    retry_delay: Duration,
 }
 
 impl RpcCatchup {
@@ -32,6 +34,7 @@ impl RpcCatchup {
             stake_table_addr: opt.stake_table_address,
             reward_addr: opt.reward_contract_address,
             chunk_size: opt.l1_events_max_block_range,
+            retry_delay: opt.l1_retry_delay,
         })
     }
 }
@@ -65,18 +68,33 @@ impl L1Catchup for RpcCatchup {
         );
 
         // To avoid making large RPC calls, divide the range into smaller chunks.
-        let chunks = block_range_chunks(from + 1, finalized.number(), self.chunk_size);
+        let target = finalized.number();
+        let chunks = block_range_chunks(from + 1, target, self.chunk_size);
 
+        let max_delay = self.retry_delay * 32;
         let mut events = BTreeMap::new();
         for (from, to) in chunks {
-            tracing::debug!(from, to, "fetch L1 events in chunk");
-            let chunk_events = get_events(
-                &self.provider,
-                Filter::new().from_block(from).to_block(to),
-                self.stake_table_addr,
-                self.reward_addr,
-            )
-            .await?;
+            tracing::info!(from, to, target, "catchup progress");
+            let mut delay = self.retry_delay;
+            let mut attempt = 0u32;
+            let chunk_events = loop {
+                match get_events(
+                    &self.provider,
+                    Filter::new().from_block(from).to_block(to),
+                    self.stake_table_addr,
+                    self.reward_addr,
+                )
+                .await
+                {
+                    Ok(events) => break events,
+                    Err(err) => {
+                        attempt += 1;
+                        tracing::warn!(from, to, attempt, ?err, "fetch L1 events failed, retrying");
+                        sleep(delay).await;
+                        delay = (delay * 2).min(max_delay);
+                    }
+                }
+            };
             events.extend(chunk_events);
         }
 

--- a/src/input/l1/rpc_catchup.rs
+++ b/src/input/l1/rpc_catchup.rs
@@ -1,12 +1,13 @@
 //! L1 catchup based on a JSON-RPC provider.
 
-use std::{cmp::min, collections::BTreeMap};
+use std::{cmp::min, collections::BTreeMap, time::Duration};
 
 use alloy::{
     eips::BlockId,
     providers::{Provider, RootProvider},
     rpc::types::Filter,
 };
+use tokio::time::sleep;
 
 use crate::{
     Error, Result,
@@ -21,6 +22,7 @@ pub struct RpcCatchup {
     stake_table_addr: Address,
     reward_addr: Address,
     chunk_size: u64,
+    retry_delay: Duration,
 }
 
 impl RpcCatchup {
@@ -32,6 +34,7 @@ impl RpcCatchup {
             stake_table_addr: opt.stake_table_address,
             reward_addr: opt.reward_contract_address,
             chunk_size: opt.l1_events_max_block_range,
+            retry_delay: opt.l1_retry_delay,
         })
     }
 }
@@ -65,18 +68,33 @@ impl L1Catchup for RpcCatchup {
         );
 
         // To avoid making large RPC calls, divide the range into smaller chunks.
-        let chunks = block_range_chunks(from + 1, finalized.number(), self.chunk_size);
+        let target = finalized.number();
+        let chunks = block_range_chunks(from + 1, target, self.chunk_size);
 
+        let max_delay = self.retry_delay * 32;
         let mut events = BTreeMap::new();
         for (from, to) in chunks {
-            tracing::debug!(from, to, "fetch L1 events in chunk");
-            let chunk_events = get_events(
-                &self.provider,
-                Filter::new().from_block(from).to_block(to),
-                self.stake_table_addr,
-                self.reward_addr,
-            )
-            .await?;
+            tracing::debug!(from, to, target, "catchup progress");
+            let mut delay = self.retry_delay;
+            let mut attempt = 0u32;
+            let chunk_events = loop {
+                match get_events(
+                    &self.provider,
+                    Filter::new().from_block(from).to_block(to),
+                    self.stake_table_addr,
+                    self.reward_addr,
+                )
+                .await
+                {
+                    Ok(events) => break events,
+                    Err(err) => {
+                        attempt += 1;
+                        tracing::warn!(from, to, attempt, ?err, "fetch L1 events failed, retrying");
+                        sleep(delay).await;
+                        delay = (delay * 2).min(max_delay);
+                    }
+                }
+            };
             events.extend(chunk_events);
         }
 

--- a/src/input/l1/rpc_catchup.rs
+++ b/src/input/l1/rpc_catchup.rs
@@ -1,13 +1,12 @@
 //! L1 catchup based on a JSON-RPC provider.
 
-use std::{cmp::min, collections::BTreeMap, time::Duration};
+use std::{cmp::min, collections::BTreeMap};
 
 use alloy::{
     eips::BlockId,
     providers::{Provider, RootProvider},
     rpc::types::Filter,
 };
-use tokio::time::sleep;
 
 use crate::{
     Error, Result,
@@ -22,7 +21,6 @@ pub struct RpcCatchup {
     stake_table_addr: Address,
     reward_addr: Address,
     chunk_size: u64,
-    retry_delay: Duration,
 }
 
 impl RpcCatchup {
@@ -34,7 +32,6 @@ impl RpcCatchup {
             stake_table_addr: opt.stake_table_address,
             reward_addr: opt.reward_contract_address,
             chunk_size: opt.l1_events_max_block_range,
-            retry_delay: opt.l1_retry_delay,
         })
     }
 }
@@ -68,33 +65,18 @@ impl L1Catchup for RpcCatchup {
         );
 
         // To avoid making large RPC calls, divide the range into smaller chunks.
-        let target = finalized.number();
-        let chunks = block_range_chunks(from + 1, target, self.chunk_size);
+        let chunks = block_range_chunks(from + 1, finalized.number(), self.chunk_size);
 
-        let max_delay = self.retry_delay * 32;
         let mut events = BTreeMap::new();
         for (from, to) in chunks {
-            tracing::info!(from, to, target, "catchup progress");
-            let mut delay = self.retry_delay;
-            let mut attempt = 0u32;
-            let chunk_events = loop {
-                match get_events(
-                    &self.provider,
-                    Filter::new().from_block(from).to_block(to),
-                    self.stake_table_addr,
-                    self.reward_addr,
-                )
-                .await
-                {
-                    Ok(events) => break events,
-                    Err(err) => {
-                        attempt += 1;
-                        tracing::warn!(from, to, attempt, ?err, "fetch L1 events failed, retrying");
-                        sleep(delay).await;
-                        delay = (delay * 2).min(max_delay);
-                    }
-                }
-            };
+            tracing::debug!(from, to, "fetch L1 events in chunk");
+            let chunk_events = get_events(
+                &self.provider,
+                Filter::new().from_block(from).to_block(to),
+                self.stake_table_addr,
+                self.reward_addr,
+            )
+            .await?;
             events.extend(chunk_events);
         }
 

--- a/src/persistence/sql.rs
+++ b/src/persistence/sql.rs
@@ -460,7 +460,7 @@ impl Persistence {
                 // event does not contain enough information to accurately correlate every
                 // withdrawal to the correct pending withdrawal. Thus, it is possible that a
                 // previous withdrawal that was meant to clear a pending withdrawal from this node
-                // got misinterpeted as clearing a different pending withdrawal, leaving a stale
+                // got misinterpreted as clearing a different pending withdrawal, leaving a stale
                 // withdrawal to this node in our database. Now, having overwritten this stale
                 // withdrawal with a fresh one, our state should once again match the contract
                 // state.


### PR DESCRIPTION
  - Fix crash when processing V2 WithdrawalClaimed events for legacy V1 undelegations (undelegationId=0)
  - V1 Withdrawal(account, amount) has no validator address and matches pending undelegations by amount, which can consume the wrong one when multiple undelegations share the same amount
  - WithdrawalClaimed handler now falls back to matching by amount when the exact validator's pending undelegation is missing, reconciling the state
  - Add retry with exponential backoff to the L1 catchup RPC loop to survive rate limits (429s). I needed this to sync decaf locally without a premium infura account. Publicnode doesn't work because we have 1 archive node query that we don't cache and always run on startup.
  - Add regression test with 10 validators exercising both V1 and V2 claim paths