### PR TITLE
Switch to write-ahead-log mode

### DIFF
--- a/src/persistence/sql.rs
+++ b/src/persistence/sql.rs
@@ -60,7 +60,8 @@ impl Persistence {
                 .ok_or_else(|| anyhow::anyhow!("invalid path"))?,
         )?
         .create_if_missing(true)
-        .log_statements(LevelFilter::Debug);
+        .log_statements(LevelFilter::Debug)
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
 
         // Create connection pool
         let pool = SqlitePoolOptions::new()

--- a/src/persistence/sql.rs
+++ b/src/persistence/sql.rs
@@ -21,9 +21,9 @@ use futures::TryStreamExt;
 use serde_json::Value;
 use sqlx::{
     ConnectOptions, QueryBuilder,
-    sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions},
+    sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions, SqliteSynchronous},
 };
-use std::{collections::HashMap, path::PathBuf, str::FromStr};
+use std::{collections::HashMap, path::PathBuf, str::FromStr, time::Duration};
 use tracing::{instrument, log::LevelFilter};
 
 /// Options for persistence.
@@ -61,7 +61,9 @@ impl Persistence {
         )?
         .create_if_missing(true)
         .log_statements(LevelFilter::Debug)
-        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+        .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal)
+        .busy_timeout(Duration::from_secs(5))
+        .synchronous(SqliteSynchronous::Normal);
 
         // Create connection pool
         let pool = SqlitePoolOptions::new()


### PR DESCRIPTION
This is intended to fix some instability we've seen in production.

To summarize the problematic behavior:
1. A call to `apply_update` fails with error code 5898 (disk I/O error, but specifically an error in a `Delete` VFS call)
2. A subsequent call to `apply_update` for the same block number succeeds, but warns that the update has already been applied. This would seem to suggest that the previous update, which failed, actually modified the database. Because the error message lacks any additional context, it must be coming from `COMMIT` (the only place in `apply_update` where we return an error without context)
3. A subsequent call to `apply_update` for a future block number fails with an error that the update has already been applied, and this happens repeatedly, with the "last update" from the database unchanging, but the update being applied continuing to increase. This seems to suggest that at least some of the calls to `apply_update` are succeeding (otherwise we would not be able to advance to later updates), but failing to actually modify the database.

This seems at least somewhat related to the default rollback journal mode, which implements `COMMIT` by deleting the rollback journal. If this deletion were to fail due to an I/O error, I theorize that an orphaned rollback entry would be left in the file system, while the contents of the actual database would still be modified (this explains (2)). Perhaps then, any later `ROLLBACK` would erroneously apply this orphaned journal entry, resetting the database to a state where the update had not yet been applied (explaining the skipped update behavior (3)).

This is not confirmed, but it is a plausible guess, and we should be using WAL mode regardless for better throughput with concurrent readers and writers, and for consistency with the consensus node SQLite implementation, which is already using WAL mode.

