### PR TITLE
feat(l1): support StakeTable V3

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -24,6 +24,10 @@ runs:
     - uses: rui314/setup-mold@v1
     - uses: extractions/setup-just@v3
 
+    - name: Install protoc
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
     - uses: Swatinem/rust-cache@v2
       with:
         save-if: ${{ github.ref == 'refs/heads/main'  }}

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -27,5 +27,8 @@ jobs:
           shared-key: cargo-doc
       - uses: extractions/setup-just@v3
 
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Generate documentation
         run: just doc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,5 +40,8 @@ jobs:
           shared-key: cargo-clippy
       - uses: extractions/setup-just@v3
 
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Run clippy
         run: just lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: extractions/setup-just@v3
 
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main'  }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "aide"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6966317188cdfe54c58c0900a195d021294afb3ece9b7073d09e4018dbb1e3a2"
+dependencies = [
+ "axum 0.8.9",
+ "bytes 1.11.1",
+ "cfg-if",
+ "http 1.3.1",
+ "indexmap 2.12.0",
+ "schemars 0.9.0",
+ "serde",
+ "serde_json",
+ "serde_qs 0.14.0",
+ "thiserror 2.0.17",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,7 +208,7 @@ dependencies = [
 [[package]]
 name = "alloy-compat"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "ethers-core",
@@ -520,7 +541,7 @@ dependencies = [
  "lru 0.13.0",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "thiserror 2.0.17",
@@ -588,7 +609,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "tokio",
@@ -822,7 +843,7 @@ checksum = "793967215109b4a334047c810ed6db5e873ad3ea07f65cc02202bd4b810d9615"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest",
+ "reqwest 0.12.24",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1927,14 +1948,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes 1.11.1",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -1945,6 +1966,39 @@ dependencies = [
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes 1.11.1",
+ "form_urlencoded",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite 0.2.16",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1965,6 +2019,25 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes 1.11.1",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "mime",
+ "pin-project-lite 0.2.16",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2158,6 +2231,17 @@ name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.1.0"
+source = "git+https://github.com/EspressoSystems/bitvec-patch.git#42cfebad9904489dbf9e2acc38df01b49784af0e"
 dependencies = [
  "funty",
  "radium",
@@ -2458,8 +2542,9 @@ dependencies = [
 [[package]]
 name = "cdn-broker"
 version = "0.6.2-compat"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.6.2-bcompat-patch2#4dd60c168fc90514b0f9c0cd33673768474baa53"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=20260519-keep-alive#56a540d4f226146c38debb7d29edf2703bbe81de"
 dependencies = [
+ "anyhow",
  "cdn-proto",
  "clap 4.5.51",
  "console-subscriber",
@@ -2471,6 +2556,7 @@ dependencies = [
  "portpicker",
  "prometheus 0.13.4",
  "rand 0.8.5",
+ "reqwest 0.12.24",
  "rkyv",
  "tokio",
  "tracing",
@@ -2480,7 +2566,7 @@ dependencies = [
 [[package]]
 name = "cdn-client"
 version = "0.6.2"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.6.2-bcompat-patch2#4dd60c168fc90514b0f9c0cd33673768474baa53"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=20260519-keep-alive#56a540d4f226146c38debb7d29edf2703bbe81de"
 dependencies = [
  "cdn-proto",
  "clap 4.5.51",
@@ -2496,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "cdn-marshal"
 version = "0.6.2-compat"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.6.2-bcompat-patch2#4dd60c168fc90514b0f9c0cd33673768474baa53"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=20260519-keep-alive#56a540d4f226146c38debb7d29edf2703bbe81de"
 dependencies = [
  "cdn-proto",
  "clap 4.5.51",
@@ -2509,7 +2595,7 @@ dependencies = [
 [[package]]
 name = "cdn-proto"
 version = "0.6.2-compat"
-source = "git+https://github.com/EspressoSystems/Push-CDN?tag=0.6.2-bcompat-patch2#4dd60c168fc90514b0f9c0cd33673768474baa53"
+source = "git+https://github.com/EspressoSystems/Push-CDN?tag=20260519-keep-alive#56a540d4f226146c38debb7d29edf2703bbe81de"
 dependencies = [
  "anyhow",
  "ark-serialize 0.5.0",
@@ -2531,6 +2617,7 @@ dependencies = [
  "rkyv",
  "rustls 0.23.34",
  "rustls-pki-types",
+ "socket2 0.6.1",
  "sqlx",
  "thiserror 1.0.69",
  "tokio",
@@ -2723,7 +2810,7 @@ checksum = "021080b0a3dbefcf1c1f0b3ad6a923b81f16801d874ec338c168ac0b0762baf5"
 [[package]]
 name = "client"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2739,19 +2826,20 @@ dependencies = [
 [[package]]
 name = "cliquenet"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
- "bimap",
  "bon",
+ "bs58",
  "bytes 1.11.1",
- "hotshot-types",
- "nohash-hasher",
+ "ed25519-compact",
  "parking_lot",
  "rand 0.10.1",
- "scopeguard",
+ "serde",
+ "serde_bytes",
  "snow",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2788,7 +2876,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74b169b26623ff17e9db37a539fe4f15342080df39f129ef7631df7683d6d9d4"
 dependencies = [
- "bitvec",
+ "bitvec 1.0.1",
  "coins-bip32",
  "hmac 0.12.1",
  "once_cell",
@@ -2867,7 +2955,7 @@ source = "git+https://github.com/EspressoSystems/commit.git#06d96ffd5199f132637c
 dependencies = [
  "arbitrary",
  "ark-serialize 0.5.0",
- "bitvec",
+ "bitvec 1.0.1",
  "derivative",
  "derive_more 0.99.20",
  "funty",
@@ -2924,9 +3012,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
 dependencies = [
  "futures-core",
- "prost",
- "prost-types",
- "tonic",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "tonic 0.12.3",
  "tracing-core",
 ]
 
@@ -2943,14 +3031,14 @@ dependencies = [
  "hdrhistogram",
  "humantime",
  "hyper-util",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "serde",
  "serde_json",
  "thread_local",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.20",
@@ -3473,7 +3561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.108",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -3728,7 +3816,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3987,13 +4075,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "espresso-api"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
+dependencies = [
+ "aide",
+ "anyhow",
+ "async-trait",
+ "axum 0.8.9",
+ "base64 0.22.1",
+ "hex",
+ "prost 0.14.4",
+ "schemars 0.9.0",
+ "serde",
+ "serde_json",
+ "serialization-api",
+ "tokio",
+ "tonic 0.14.6",
+ "tonic-build",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tonic-reflection",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-subscriber 0.3.20",
 ]
 
 [[package]]
 name = "espresso-contract-deployer"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4028,16 +4143,19 @@ dependencies = [
 [[package]]
 name = "espresso-node"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
+ "async-broadcast",
  "async-channel 2.5.0",
  "async-lock 3.4.1",
  "async-once-cell",
  "async-trait",
+ "base64 0.22.1",
+ "base64-bytes",
  "bincode",
  "blake3",
  "byteorder",
@@ -4052,7 +4170,9 @@ dependencies = [
  "derive_more 2.0.1",
  "dotenvy",
  "either",
+ "espresso-api",
  "espresso-contract-deployer",
+ "espresso-telemetry",
  "espresso-types",
  "espresso-utils",
  "futures",
@@ -4062,6 +4182,7 @@ dependencies = [
  "hotshot-contract-adapter",
  "hotshot-events-service",
  "hotshot-libp2p-networking",
+ "hotshot-new-protocol",
  "hotshot-orchestrator",
  "hotshot-query-service",
  "hotshot-state-prover",
@@ -4082,16 +4203,19 @@ dependencies = [
  "num_enum",
  "parking_lot",
  "priority-queue",
+ "process-metrics",
+ "prometheus 0.13.4",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_distr",
  "request-response",
- "reqwest",
+ "reqwest 0.12.24",
  "rstest",
  "rstest_reuse",
  "semver 1.0.27",
  "serde",
  "serde_json",
+ "serialization-api",
  "sha2 0.10.9",
  "snafu 0.8.9",
  "sqlx",
@@ -4122,7 +4246,7 @@ dependencies = [
 [[package]]
 name = "espresso-safe-tx-builder"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4137,12 +4261,44 @@ version = "0.4.0"
 source = "git+https://github.com/espressosystems/espresso-systems-common?tag=0.4.0#5abd890f79014a86db31286e1f3a529f161e69de"
 
 [[package]]
+name = "espresso-telemetry"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
+dependencies = [
+ "anyhow",
+ "ark-serialize 0.5.0",
+ "base64 0.22.1",
+ "clap 4.5.51",
+ "derivative",
+ "jf-signature 0.4.0 (git+https://github.com/EspressoSystems/jellyfish?tag=jf-signature-v0.4.0)",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "prometheus 0.13.4",
+ "prost 0.14.4",
+ "prost-build",
+ "rand 0.8.5",
+ "reqwest 0.12.24",
+ "serde",
+ "serde_json",
+ "snap",
+ "tagged-base64",
+ "thiserror 2.0.17",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.20",
+ "url",
+]
+
+[[package]]
 name = "espresso-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "alloy-compat",
+ "alloy-rlp",
  "anyhow",
  "ark-ec",
  "ark-serialize 0.5.0",
@@ -4169,7 +4325,8 @@ dependencies = [
  "hotshot-contract-adapter",
  "hotshot-example-types",
  "hotshot-libp2p-networking",
- "hotshot-query-service",
+ "hotshot-new-protocol",
+ "hotshot-query-service-types",
  "hotshot-types",
  "humantime",
  "indexmap 2.12.0",
@@ -4210,7 +4367,7 @@ dependencies = [
 [[package]]
 name = "espresso-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4227,6 +4384,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-subscriber 0.3.20",
  "url",
  "vergen 9.1.0",
  "vergen-gitcl",
@@ -5148,7 +5306,7 @@ dependencies = [
 [[package]]
 name = "hotshot"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5163,7 +5321,6 @@ dependencies = [
  "cdn-client",
  "cdn-marshal",
  "chrono",
- "cliquenet",
  "committable",
  "dashmap",
  "derive_more 2.0.1",
@@ -5194,7 +5351,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-api"
 version = "0.1.7"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "async-trait",
  "clap 4.5.51",
@@ -5213,7 +5370,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-refactored"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -5245,7 +5402,7 @@ dependencies = [
 [[package]]
 name = "hotshot-builder-shared"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -5284,7 +5441,7 @@ dependencies = [
 [[package]]
 name = "hotshot-contract-adapter"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5297,6 +5454,7 @@ dependencies = [
  "ark-std 0.5.0",
  "derive_more 2.0.1",
  "hotshot-types",
+ "hotshot-utils",
  "jf-pcs",
  "jf-plonk 0.7.0 (git+https://github.com/EspressoSystems/jellyfish?tag=jf-plonk-v0.7.0)",
  "jf-plonk 0.7.0 (git+https://github.com/EspressoSystems/jellyfish?branch=jf-relation-v0.5.0-compat)",
@@ -5308,12 +5466,13 @@ dependencies = [
  "serde",
  "serde_arrays",
  "thiserror 2.0.17",
+ "tracing",
 ]
 
 [[package]]
 name = "hotshot-events-service"
 version = "0.1.57"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "async-broadcast",
@@ -5338,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "hotshot-example-types"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5354,7 +5513,7 @@ dependencies = [
  "hotshot-utils",
  "jf-advz",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "sha2 0.10.9",
  "sha3",
@@ -5370,7 +5529,7 @@ dependencies = [
 [[package]]
 name = "hotshot-libp2p-networking"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5401,7 +5560,7 @@ dependencies = [
 [[package]]
 name = "hotshot-macros"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "derive_builder",
  "proc-macro2",
@@ -5410,9 +5569,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "hotshot-new-protocol"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
+dependencies = [
+ "alloy",
+ "anyhow",
+ "async-broadcast",
+ "async-lock 3.4.1",
+ "async-trait",
+ "bon",
+ "cliquenet",
+ "committable",
+ "futures",
+ "hotshot",
+ "hotshot-contract-adapter",
+ "hotshot-example-types",
+ "hotshot-testing",
+ "hotshot-types",
+ "hotshot-utils",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "test-utils",
+ "thiserror 2.0.17",
+ "time 0.3.47",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.20",
+ "versions",
+]
+
+[[package]]
 name = "hotshot-orchestrator"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5436,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "hotshot-query-service"
 version = "0.1.76"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5457,6 +5648,8 @@ dependencies = [
  "hotshot",
  "hotshot-events-service",
  "hotshot-example-types",
+ "hotshot-new-protocol",
+ "hotshot-query-service-types",
  "hotshot-testing",
  "hotshot-types",
  "include_dir",
@@ -5493,9 +5686,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "hotshot-query-service-types"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
+dependencies = [
+ "anyhow",
+ "ark-serialize 0.5.0",
+ "bincode",
+ "committable",
+ "derivative",
+ "derive_more 2.0.1",
+ "either",
+ "hotshot-events-service",
+ "hotshot-example-types",
+ "hotshot-types",
+ "itertools 0.14.0",
+ "jf-advz",
+ "jf-merkle-tree-compat",
+ "serde",
+ "serde_json",
+ "snafu 0.8.9",
+ "sqlx",
+ "surf-disco",
+ "tagged-base64",
+ "tide-disco",
+ "time 0.3.47",
+ "vbs",
+ "versions",
+]
+
+[[package]]
 name = "hotshot-state-prover"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5528,7 +5751,7 @@ dependencies = [
  "jf-signature 0.4.0 (git+https://github.com/EspressoSystems/jellyfish?tag=jf-signature-v0.4.0)",
  "jf-signature 0.4.0 (git+https://github.com/EspressoSystems/jellyfish?branch=jf-relation-v0.5.0-compat)",
  "jf-utils",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "surf-disco",
  "tide-disco",
@@ -5543,7 +5766,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -5556,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "hotshot-task-impls"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5572,6 +5795,7 @@ dependencies = [
  "futures",
  "hotshot-builder-api",
  "hotshot-contract-adapter",
+ "hotshot-libp2p-networking",
  "hotshot-task",
  "hotshot-types",
  "hotshot-utils",
@@ -5595,7 +5819,7 @@ dependencies = [
 [[package]]
 name = "hotshot-testing"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5604,7 +5828,7 @@ dependencies = [
  "async-trait",
  "automod",
  "bincode",
- "bitvec",
+ "bitvec 1.1.0",
  "committable",
  "either",
  "futures",
@@ -5620,7 +5844,7 @@ dependencies = [
  "jf-advz",
  "lru 0.12.5",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "sha2 0.10.9",
  "tagged-base64",
@@ -5638,9 +5862,10 @@ dependencies = [
 [[package]]
 name = "hotshot-types"
 version = "0.1.11"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
+ "alloy-rlp",
  "anyhow",
  "ark-bn254",
  "ark-ed-on-bn254",
@@ -5652,16 +5877,16 @@ dependencies = [
  "async-lock 3.4.1",
  "async-trait",
  "bincode",
- "bitvec",
+ "bitvec 1.1.0",
  "blake3",
  "bs58",
  "clap 4.5.51",
+ "cliquenet",
  "committable",
  "derive_more 2.0.1",
  "digest 0.10.7",
  "displaydoc",
  "dyn-clone",
- "ed25519-compact",
  "either",
  "futures",
  "generic-array 1.3.5",
@@ -5703,7 +5928,7 @@ dependencies = [
 [[package]]
 name = "hotshot-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "tracing",
 ]
@@ -5795,7 +6020,7 @@ dependencies = [
  "rand 0.7.3",
  "serde",
  "serde_json",
- "serde_qs",
+ "serde_qs 0.8.5",
  "serde_urlencoded",
  "url",
 ]
@@ -5929,7 +6154,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite 0.2.16",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6105,7 +6330,7 @@ dependencies = [
  "rtnetlink",
  "system-configuration",
  "tokio",
- "windows",
+ "windows 0.53.0",
 ]
 
 [[package]]
@@ -6297,16 +6522,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -7313,20 +7528,24 @@ dependencies = [
 [[package]]
 name = "light-client"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
+ "alloy-rlp",
  "anyhow",
  "async-lock 3.4.1",
- "bitvec",
+ "async-trait",
+ "bitvec 1.1.0",
  "clap 4.5.51",
  "committable",
  "derivative",
+ "derive_builder",
  "derive_more 2.0.1",
  "espresso-types",
  "futures",
  "hotshot-contract-adapter",
  "hotshot-query-service",
+ "hotshot-query-service-types",
  "hotshot-types",
  "jf-advz",
  "jf-merkle-tree-compat",
@@ -7336,6 +7555,7 @@ dependencies = [
  "sqlx",
  "static_assertions",
  "surf-disco",
+ "tempfile",
  "tokio",
  "tracing",
  "vbs",
@@ -7480,6 +7700,12 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maud"
@@ -7676,6 +7902,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
 name = "multistream-select"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7809,12 +8041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nohash-hasher"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7831,12 +8057,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07626f57b1cb0ee81e5193d331209751d2e18ffa3ceaa0fd6fab63db31fafd9"
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8109,6 +8344,93 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite 0.2.16",
+ "thiserror 2.0.17",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber 0.3.20",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes 1.11.1",
+ "http 1.3.1",
+ "opentelemetry",
+ "reqwest 0.13.4",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "flate2",
+ "http 1.3.1",
+ "httpdate",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost 0.14.4",
+ "reqwest 0.13.4",
+ "thiserror 2.0.17",
+ "tokio",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost 0.14.4",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.2",
+ "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8146,7 +8468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec",
- "bitvec",
+ "bitvec 1.0.1",
  "byte-slice-cast",
  "const_format",
  "impl-trait-for-tuples",
@@ -8284,6 +8606,17 @@ checksum = "72f27a2cfee9f9039c4d86faa5af122a0ac3851441a34865b8a043b46be0065a"
 dependencies = [
  "pest",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.12.0",
 ]
 
 [[package]]
@@ -8644,6 +8977,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-metrics"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
+dependencies = [
+ "hotshot-types",
+ "procfs",
+ "sysinfo",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "procfs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7"
+dependencies = [
+ "bitflags 2.10.0",
+ "chrono",
+ "flate2",
+ "procfs-core",
+ "rustix 1.1.2",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405"
+dependencies = [
+ "bitflags 2.10.0",
+ "chrono",
+ "hex",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8732,7 +9101,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes 1.11.1",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes 1.11.1",
+ "prost-derive 0.14.4",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck 0.4.1",
+ "itertools 0.10.5",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
+ "regex",
+ "syn 2.0.108",
+ "tempfile",
 ]
 
 [[package]]
@@ -8749,12 +9149,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -8775,6 +9197,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.10.0",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -8831,7 +9273,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.34",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -8868,9 +9310,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9267,7 +9709,7 @@ dependencies = [
 [[package]]
 name = "request-response"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -9332,6 +9774,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes 1.11.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite 0.2.16",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.2",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9391,7 +9864,7 @@ version = "0.7.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
 dependencies = [
- "bitvec",
+ "bitvec 1.0.1",
  "bytecheck",
  "bytes 1.11.1",
  "hashbrown 0.12.3",
@@ -9691,7 +10164,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9827,7 +10300,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
 dependencies = [
  "dyn-clone",
+ "indexmap 2.12.0",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
 ]
@@ -9842,6 +10317,18 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5016d94c77c6d32f0b8e08b781f7dc8a90c2007d4e77472cc2807bc10a8438fe"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -10041,6 +10528,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "serde_fmt"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10063,6 +10561,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_qs"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10071,6 +10580,19 @@ dependencies = [
  "percent-encoding",
  "serde",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "serde_qs"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b417bedc008acbdf6d6b4bc482d29859924114bbe2650b7921fb68a261d0aa6"
+dependencies = [
+ "axum 0.8.9",
+ "futures",
+ "percent-encoding",
+ "serde",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -10133,6 +10655,20 @@ checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
  "base16ct",
  "serde",
+]
+
+[[package]]
+name = "serialization-api"
+version = "0.1.0"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
+dependencies = [
+ "anyhow",
+ "prost 0.14.4",
+ "prost-build",
+ "schemars 0.9.0",
+ "serde",
+ "serde_json",
+ "toml",
 ]
 
 [[package]]
@@ -10408,6 +10944,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "snow"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10527,6 +11069,7 @@ checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
 dependencies = [
  "bit-vec 0.6.3",
  "bytes 1.11.1",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -10605,6 +11148,7 @@ dependencies = [
  "bitflags 2.10.0",
  "byteorder",
  "bytes 1.11.1",
+ "chrono",
  "crc",
  "digest 0.10.7",
  "dotenvy",
@@ -10648,6 +11192,7 @@ dependencies = [
  "bit-vec 0.6.3",
  "bitflags 2.10.0",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -10683,6 +11228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f85ca71d3a5b24e64e1d08dd8fe36c6c95c339a896cc33068148906784620540"
 dependencies = [
  "atoi",
+ "chrono",
  "flume 0.11.1",
  "futures-channel",
  "futures-core",
@@ -10709,7 +11255,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "staking-cli"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "alloy",
  "anyhow",
@@ -10733,7 +11279,7 @@ dependencies = [
  "prometheus-parse",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
- "reqwest",
+ "reqwest 0.12.24",
  "rstest",
  "rstest_reuse",
  "rust_decimal",
@@ -10757,7 +11303,7 @@ dependencies = [
  "async-lock 3.4.1",
  "async-trait",
  "bigdecimal",
- "bitvec",
+ "bitvec 1.1.0",
  "clap 4.5.51",
  "cld",
  "committable",
@@ -10781,7 +11327,7 @@ dependencies = [
  "prometheus 0.14.0",
  "prometheus-parse",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "sqlx",
@@ -10967,7 +11513,7 @@ dependencies = [
  "derivative",
  "futures",
  "hex",
- "reqwest",
+ "reqwest 0.12.24",
  "serde",
  "serde_json",
  "tide-disco",
@@ -11108,6 +11654,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.33.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+ "memchr",
+ "ntapi",
+ "rayon",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11176,7 +11736,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11204,7 +11764,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 
 [[package]]
 name = "textwrap"
@@ -11321,7 +11881,7 @@ dependencies = [
  "pin-project",
  "prometheus 0.13.4",
  "rand 0.8.5",
- "reqwest",
+ "reqwest 0.12.24",
  "routefinder",
  "semver 1.0.27",
  "serde",
@@ -11582,6 +12142,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
+ "hashbrown 0.15.5",
  "pin-project-lite 0.2.16",
  "tokio",
 ]
@@ -11665,7 +12226,7 @@ checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes 1.11.1",
  "h2 0.4.12",
@@ -11677,7 +12238,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2 0.5.10",
  "tokio",
  "tokio-stream",
@@ -11685,6 +12246,88 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "axum 0.8.9",
+ "base64 0.22.1",
+ "bytes 1.11.1",
+ "h2 0.4.12",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.7.0",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes 1.11.1",
+ "prost 0.14.4",
+ "tonic 0.14.6",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types 0.14.4",
+ "quote",
+ "syn 2.0.108",
+ "tempfile",
+ "tonic-build",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acccd136a4bf19810a1fde9c74edc6129b42a66b44d0c1c8aaa67aeb49a146a7"
+dependencies = [
+ "prost 0.14.4",
+ "prost-types 0.14.4",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.14.6",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -11715,29 +12358,33 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.12.0",
  "pin-project-lite 0.2.16",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags 2.10.0",
  "bytes 1.11.1",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite 0.2.16",
  "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -12259,7 +12906,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "versions"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "bincode",
  "serde",
@@ -12270,7 +12917,7 @@ dependencies = [
 [[package]]
 name = "vid"
 version = "0.1.0"
-source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260414#2eddd53b8c077155dd0fa56d8ee28f6f95772cc1"
+source = "git+https://github.com/EspressoSystems/espresso-network.git?tag=20260707#0d84448cd1a487e05fb57657218f08894aa2f733"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -12631,7 +13278,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -12647,6 +13294,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
 dependencies = [
  "windows-core 0.53.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.57.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+dependencies = [
+ "windows-core 0.57.0",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ alloy = { version = "1.0", features = [
 anyhow = "1"
 async-lock = "3.0"
 bigdecimal = "0.4.8"
-bitvec = "1"
+bitvec = { git = "https://github.com/EspressoSystems/bitvec-patch.git", features = [
+    "serde",
+] }
 clap = { version = "4.4", features = ["derive", "env"] }
 cld = "0.5"
 committable = { git = "https://github.com/EspressoSystems/commit.git", features = [
@@ -41,12 +43,12 @@ committable = { git = "https://github.com/EspressoSystems/commit.git", features 
 ] }
 derivative = "2"
 derive_more = "2.0"
-espresso-types = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260414" }
+espresso-types = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260707" }
 futures = "0.3"
 hickory-resolver = "0.25"
-hotshot-contract-adapter = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260414" }
-hotshot-query-service = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260414" }
-hotshot-types = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260414" }
+hotshot-contract-adapter = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260707" }
+hotshot-query-service = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260707" }
+hotshot-types = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260707" }
 im = { version = "15", features = ["serde"] }
 log-panics = { version = "2.0", features = ["with-backtrace"] }
 parking_lot = "0.12"
@@ -68,19 +70,19 @@ vbs = "0.1"
 
 # Testing dependencies
 async-trait = "0.1.89"
-espresso-contract-deployer = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260414", optional = true }
-espresso-node = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260414", features = [
+espresso-contract-deployer = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260707", optional = true }
+espresso-node = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260707", features = [
     "embedded-db",
     "testing",
 ], optional = true }
-hotshot-state-prover = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260414", optional = true }
+hotshot-state-prover = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260707", optional = true }
 jf-signature = { git = "https://github.com/EspressoSystems/jellyfish", tag = "jf-signature-v0.4.0", features = [
     "std",
 ], optional = true }
 pretty_assertions = { version = "1", optional = true }
 rand = { version = "0.8", optional = true }
-staking-cli = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260414", optional = true }
-versions = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260414", optional = true }
+staking-cli = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260707", optional = true }
+versions = { git = "https://github.com/EspressoSystems/espresso-network.git", tag = "20260707", optional = true }
 
 [build-dependencies]
 anyhow = "1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -230,8 +230,8 @@ mod test {
     use tokio::{task::spawn, time::sleep};
 
     use crate::types::{common::U256, wallet::WalletDiff};
-    use hotshot_contract_adapter::sol_types::StakeTableV2::{
-        Delegated, StakeTableV2Events, Undelegated,
+    use hotshot_contract_adapter::sol_types::StakeTableV3::{
+        Delegated, StakeTableV3Events, Undelegated,
     };
 
     use crate::{
@@ -367,7 +367,7 @@ mod test {
         let mut inputs = VecStream::infinite();
         inputs.push(
             BlockInput::empty(2)
-                .with_event(StakeTableV2Events::ValidatorRegisteredV2(node.clone())),
+                .with_event(StakeTableV3Events::ValidatorRegisteredV2(node.clone())),
         );
         subscribe_until(&l1, inputs, |l1| l1.latest_l1_block().number == 2).await;
 
@@ -467,8 +467,8 @@ mod test {
 
         inputs.push(
             BlockInput::empty(2)
-                .with_event(StakeTableV2Events::ValidatorRegisteredV2(validator.clone()))
-                .with_event(StakeTableV2Events::Delegated(Delegated {
+                .with_event(StakeTableV3Events::ValidatorRegisteredV2(validator.clone()))
+                .with_event(StakeTableV3Events::Delegated(Delegated {
                     delegator,
                     validator: validator_address,
                     amount: U256::from(1000),
@@ -476,7 +476,7 @@ mod test {
         );
 
         inputs.push(
-            BlockInput::empty(3).with_event(StakeTableV2Events::Undelegated(Undelegated {
+            BlockInput::empty(3).with_event(StakeTableV3Events::Undelegated(Undelegated {
                 delegator,
                 validator: validator_address,
                 amount: U256::from(400),

--- a/src/input/espresso.rs
+++ b/src/input/espresso.rs
@@ -525,18 +525,19 @@ impl EpochState {
         let active_nodes = nodes.keys().copied().collect::<Vec<_>>();
         let validators: Vec<_> = nodes.values().cloned().collect();
 
-        // Index active nodes by staking key.
+        // Index active nodes by staking key. `AuthenticatedValidator` guarantees a
+        // consensus key is present, so `stake_table_key()` never panics here.
         let node_index = nodes
             .values()
             .enumerate()
-            .map(|(i, node)| (node.stake_table_key, i))
+            .map(|(i, node)| (*node.stake_table_key(), i))
             .collect();
 
         // Pre-process a randomized committee for leader election.
         let entries = nodes
             .values()
             .map(|node| StakeTableEntry {
-                stake_key: node.stake_table_key,
+                stake_key: *node.stake_table_key(),
                 stake_amount: node.stake,
             })
             .collect();

--- a/src/input/espresso/client.rs
+++ b/src/input/espresso/client.rs
@@ -815,10 +815,9 @@ mod test {
     ) -> AuthenticatedValidatorMap {
         network
             .server
-            .consensus()
-            .read()
+            .consensus_handle()
+            .membership_coordinator()
             .await
-            .membership_coordinator
             .stake_table_for_epoch(Some(epoch))
             .await
             .unwrap()

--- a/src/input/espresso/testing.rs
+++ b/src/input/espresso/testing.rs
@@ -106,8 +106,8 @@ impl EspressoClient for MockEspressoClient {
                 let stake = ESPTokenAmount::from(1);
                 let node = RegisteredValidator {
                     account,
-                    stake_table_key,
-                    state_ver_key,
+                    stake_table_key: Some(stake_table_key),
+                    state_ver_key: Some(state_ver_key),
                     x25519_key: None,
                     p2p_addr: None,
                     stake,

--- a/src/input/l1.rs
+++ b/src/input/l1.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{BTreeMap, HashMap},
+    fmt,
     sync::Arc,
     time::Duration,
 };
@@ -14,9 +15,12 @@ use futures::{
     future::join_all,
     stream::{Stream, StreamExt},
 };
-use hotshot_contract_adapter::sol_types::{
-    RewardClaim::RewardClaimEvents,
-    StakeTableV2::{StakeTableV2Events, ValidatorRegistered},
+use hotshot_contract_adapter::{
+    sol_types::{
+        RewardClaim::RewardClaimEvents,
+        StakeTableV3::{StakeTableV3Events, ValidatorRegistered},
+    },
+    stake_table::StakeTableSolError,
 };
 use hotshot_types::light_client::StateVerKey;
 use tokio::time::sleep;
@@ -640,42 +644,66 @@ impl Snapshot {
         tracing::debug!("processing L1 event");
         match event {
             L1Event::StakeTable(ev) => match ev.as_ref() {
-                StakeTableV2Events::ValidatorRegisteredV2(ev) => {
-                    // Authenticate signatures.
-                    if let Err(err) = ev.authenticate() {
-                        // The contract doesn't check all the signatures, so it's possible that an
-                        // invalid event got through. We can safely just ignore it as the consensus
-                        // protocol will do the same.
-                        tracing::warn!("got invalid ValidatorRegisteredV2 event: {err:#}");
-                        return Default::default();
-                    }
-
-                    // Downgrade the event: apart from authentication and metadata, the V2 event
-                    // contains the same information as the V1 event, and can be converted to a node
-                    // the same way.
-                    let legacy = ValidatorRegistered {
-                        account: ev.account,
-                        blsVk: ev.blsVK,
-                        commission: ev.commission,
-                        schnorrVk: ev.schnorrVK,
+                // V2 events remain in the on-chain history, so both must be handled. The V3 event
+                // additionally carries an x25519 key and p2p address, which this service ignores.
+                ev @ (StakeTableV3Events::ValidatorRegisteredV2(_)
+                | StakeTableV3Events::ValidatorRegisteredV3(_)) => {
+                    // Authenticate signatures. The contract doesn't check all the signatures, so an
+                    // invalid event may get through. We can safely ignore it as the consensus
+                    // protocol will do the same.
+                    let (mut node, metadata_uri): (NodeSetEntry, &str) = match ev {
+                        StakeTableV3Events::ValidatorRegisteredV2(ev) => {
+                            let (bls, schnorr) = match ev.authenticate() {
+                                Ok(keys) => keys,
+                                Err(err) => {
+                                    tracing::warn!(
+                                        "got invalid ValidatorRegisteredV2 event: {err:#}"
+                                    );
+                                    return Default::default();
+                                }
+                            };
+                            (
+                                node_set_entry(ev.account, ev.commission, bls, schnorr),
+                                &ev.metadataUri,
+                            )
+                        }
+                        StakeTableV3Events::ValidatorRegisteredV3(ev) => {
+                            let (bls, schnorr) = match ev.authenticate() {
+                                Ok(keys) => keys,
+                                Err(err) => {
+                                    tracing::warn!(
+                                        "got invalid ValidatorRegisteredV3 event: {err:#}"
+                                    );
+                                    return Default::default();
+                                }
+                            };
+                            (
+                                node_set_entry(ev.account, ev.commission, bls, schnorr),
+                                &ev.metadataUri,
+                            )
+                        }
+                        _ => unreachable!(),
                     };
-                    let mut node: NodeSetEntry = (&legacy).into();
 
                     // Download third-party metadata.
                     node.metadata = metadata_fetcher
-                        .fetch_infallible_authenticated(&ev.metadataUri, &node.staking_key)
+                        .fetch_infallible_authenticated(metadata_uri, &node.staking_key)
                         .await;
 
                     (vec![FullNodeSetDiff::NodeUpdate(Arc::new(node))], vec![])
                 }
-                StakeTableV2Events::ValidatorRegistered(ev) => {
+                StakeTableV3Events::ValidatorRegistered(ev) => {
                     tracing::warn!("received legacy ValidatorRegistered event");
-                    (
-                        vec![FullNodeSetDiff::NodeUpdate(Arc::new(ev.into()))],
-                        vec![],
-                    )
+                    let node = match NodeSetEntry::try_from(ev) {
+                        Ok(node) => node,
+                        Err(err) => {
+                            tracing::warn!("got invalid ValidatorRegistered event: {err:#}");
+                            return Default::default();
+                        }
+                    };
+                    (vec![FullNodeSetDiff::NodeUpdate(Arc::new(node))], vec![])
                 }
-                StakeTableV2Events::ExitEscrowPeriodUpdated(ev) => {
+                StakeTableV3Events::ExitEscrowPeriodUpdated(ev) => {
                     // This should be quite rare, we can be a little loud about it.
                     tracing::warn!(
                         old = self.block.exit_escrow_period,
@@ -688,13 +716,13 @@ impl Snapshot {
                     // on the node set or the wallets.
                     (vec![], vec![])
                 }
-                ev @ (StakeTableV2Events::ValidatorExit(_)
-                | StakeTableV2Events::ValidatorExitV2(_)) => {
+                ev @ (StakeTableV3Events::ValidatorExit(_)
+                | StakeTableV3Events::ValidatorExitV2(_)) => {
                     let (validator, exit_time) = match ev {
-                        StakeTableV2Events::ValidatorExit(e) => {
+                        StakeTableV3Events::ValidatorExit(e) => {
                             (e.validator, timestamp + self.block.exit_escrow_period)
                         }
-                        StakeTableV2Events::ValidatorExitV2(e) => {
+                        StakeTableV3Events::ValidatorExitV2(e) => {
                             (e.validator, e.unlocksAt.to::<u64>())
                         }
                         _ => unreachable!(),
@@ -734,7 +762,22 @@ impl Snapshot {
 
                     (vec![node_diff], wallet_diffs)
                 }
-                StakeTableV2Events::ConsensusKeysUpdated(ev) => {
+                StakeTableV3Events::ConsensusKeysUpdated(ev) => {
+                    let staking_key = match PubKey::try_from(ev.blsVK) {
+                        Ok(key) => key,
+                        Err(err) => {
+                            tracing::warn!("got invalid ConsensusKeysUpdated bls key: {err:#}");
+                            return Default::default();
+                        }
+                    };
+                    let state_key = match StateVerKey::try_from(ev.schnorrVK) {
+                        Ok(key) => key,
+                        Err(err) => {
+                            tracing::warn!("got invalid ConsensusKeysUpdated schnorr key: {err:#}");
+                            return Default::default();
+                        }
+                    };
+
                     let node = self.node_set.get(&ev.account).unwrap_or_else(|| {
                         panic!(
                             "got ConsensusKeysUpdated event for non existent validator: {}",
@@ -743,17 +786,20 @@ impl Snapshot {
                     });
 
                     let diff = FullNodeSetDiff::NodeUpdate(Arc::new(NodeSetEntry {
-                        staking_key: PubKey::from(ev.blsVK).into(),
-                        state_key: StateVerKey::from(ev.schnorrVK).into(),
+                        staking_key: staking_key.into(),
+                        state_key: state_key.into(),
                         ..node.clone()
                     }));
                     (vec![diff], vec![])
                 }
-                StakeTableV2Events::ConsensusKeysUpdatedV2(ev) => {
-                    if let Err(err) = ev.authenticate() {
-                        tracing::warn!("got invalid ConsensusKeysUpdatedV2 event: {err:#}");
-                        return Default::default();
-                    }
+                StakeTableV3Events::ConsensusKeysUpdatedV2(ev) => {
+                    let (staking_key, state_key) = match ev.authenticate() {
+                        Ok(keys) => keys,
+                        Err(err) => {
+                            tracing::warn!("got invalid ConsensusKeysUpdatedV2 event: {err:#}");
+                            return Default::default();
+                        }
+                    };
 
                     let node = self.node_set.get(&ev.account).unwrap_or_else(|| {
                         panic!(
@@ -763,13 +809,13 @@ impl Snapshot {
                     });
 
                     let diff = FullNodeSetDiff::NodeUpdate(Arc::new(NodeSetEntry {
-                        staking_key: PubKey::from(ev.blsVK).into(),
-                        state_key: StateVerKey::from(ev.schnorrVK).into(),
+                        staking_key: staking_key.into(),
+                        state_key: state_key.into(),
                         ..node.clone()
                     }));
                     (vec![diff], vec![])
                 }
-                StakeTableV2Events::CommissionUpdated(ev) => {
+                StakeTableV3Events::CommissionUpdated(ev) => {
                     let node = self.node_set.get(&ev.validator).unwrap_or_else(|| {
                         panic!(
                             "got CommissionUpdated event for non existent validator: {}",
@@ -786,7 +832,7 @@ impl Snapshot {
                     }));
                     (vec![diff], vec![])
                 }
-                StakeTableV2Events::MetadataUriUpdated(ev) => {
+                StakeTableV3Events::MetadataUriUpdated(ev) => {
                     let node = self.node_set.get(&ev.validator).unwrap_or_else(|| {
                         panic!(
                             "got MetadataUriUpdated event for non existent validator: {}",
@@ -801,7 +847,7 @@ impl Snapshot {
                     }));
                     (vec![diff], vec![])
                 }
-                StakeTableV2Events::Delegated(ev) => {
+                StakeTableV3Events::Delegated(ev) => {
                     let node = self.node_set.get(&ev.validator).unwrap_or_else(|| {
                         panic!(
                             "got Delegated event for non existent validator: {}",
@@ -824,15 +870,15 @@ impl Snapshot {
                     (vec![node_diff], vec![(ev.delegator, wallet_diff)])
                 }
                 ev
-                @ (StakeTableV2Events::Undelegated(_) | StakeTableV2Events::UndelegatedV2(_)) => {
+                @ (StakeTableV3Events::Undelegated(_) | StakeTableV3Events::UndelegatedV2(_)) => {
                     let (validator, delegator, amount, available_time) = match ev {
-                        StakeTableV2Events::Undelegated(e) => (
+                        StakeTableV3Events::Undelegated(e) => (
                             e.validator,
                             e.delegator,
                             e.amount,
                             timestamp + self.block.exit_escrow_period,
                         ),
-                        StakeTableV2Events::UndelegatedV2(e) => {
+                        StakeTableV3Events::UndelegatedV2(e) => {
                             (e.validator, e.delegator, e.amount, e.unlocksAt.to::<u64>())
                         }
                         _ => unreachable!(),
@@ -859,20 +905,20 @@ impl Snapshot {
                 }
                 // Legacy withdrawal event from the old StakeTable contract.
                 //
-                // The new StakeTableV2 contract emits `WithdrawalClaimed` and
+                // The new StakeTableV3 contract emits `WithdrawalClaimed` and
                 // `ValidatorExitClaimed` events which include the validator address.
                 //
                 // This event should never be emitted on mainnet because
                 // mainnet will have new stake table contract
-                StakeTableV2Events::Withdrawal(ev) => {
+                StakeTableV3Events::Withdrawal(ev) => {
                     panic!(
                         "Received legacy Withdrawal event account={}, amount={}. \
                         This event is from the old StakeTable contract.
-                        The StakeTableV2 contract emits WithdrawalClaimed and ValidatorExitClaimed instead.",
+                        The StakeTableV3 contract emits WithdrawalClaimed and ValidatorExitClaimed instead.",
                         ev.account, ev.amount
                     );
                 }
-                StakeTableV2Events::WithdrawalClaimed(ev) => {
+                StakeTableV3Events::WithdrawalClaimed(ev) => {
                     let wallet = self.wallets.get(&ev.delegator).unwrap_or_else(|| {
                         panic!(
                             "got WithdrawalClaimed event for non existent wallet: {}",
@@ -895,7 +941,7 @@ impl Snapshot {
                     let wallet_diff = WalletDiff::UndelegationWithdrawal(withdrawal);
                     (vec![], vec![(ev.delegator, wallet_diff)])
                 }
-                StakeTableV2Events::ValidatorExitClaimed(ev) => {
+                StakeTableV3Events::ValidatorExitClaimed(ev) => {
                     let wallet = self.wallets.get(&ev.delegator).unwrap_or_else(|| {
                         panic!(
                             "got ValidatorExitClaimed event for non existent wallet: {}",
@@ -922,17 +968,19 @@ impl Snapshot {
                 // (rather than matching on _) so that it is clear that we are not missing any
                 // important events, and if new event types are added, the compiler will force us to
                 // handle them explicitly.
-                StakeTableV2Events::MaxCommissionIncreaseUpdated(_)
-                | StakeTableV2Events::MinDelegateAmountUpdated(_)
-                | StakeTableV2Events::MinCommissionUpdateIntervalUpdated(_)
-                | StakeTableV2Events::OwnershipTransferred(_)
-                | StakeTableV2Events::Paused(_)
-                | StakeTableV2Events::Unpaused(_)
-                | StakeTableV2Events::Initialized(_)
-                | StakeTableV2Events::RoleAdminChanged(_)
-                | StakeTableV2Events::RoleGranted(_)
-                | StakeTableV2Events::RoleRevoked(_)
-                | StakeTableV2Events::Upgraded(_) => {
+                StakeTableV3Events::X25519KeyUpdated(_)
+                | StakeTableV3Events::P2pAddrUpdated(_)
+                | StakeTableV3Events::MaxCommissionIncreaseUpdated(_)
+                | StakeTableV3Events::MinDelegateAmountUpdated(_)
+                | StakeTableV3Events::MinCommissionUpdateIntervalUpdated(_)
+                | StakeTableV3Events::OwnershipTransferred(_)
+                | StakeTableV3Events::Paused(_)
+                | StakeTableV3Events::Unpaused(_)
+                | StakeTableV3Events::Initialized(_)
+                | StakeTableV3Events::RoleAdminChanged(_)
+                | StakeTableV3Events::RoleGranted(_)
+                | StakeTableV3Events::RoleRevoked(_)
+                | StakeTableV3Events::Upgraded(_) => {
                     tracing::debug!("skipping irrelevant event");
                     (vec![], vec![])
                 }
@@ -1199,13 +1247,34 @@ pub struct BlockInput {
 }
 
 /// The set of L1 events that we care about.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub enum L1Event {
     /// An event emitted by the reward claim contract.
     Reward(Arc<RewardClaimEvents>),
 
     /// An event emitted by the stake table contract.
-    StakeTable(Arc<StakeTableV2Events>),
+    StakeTable(Arc<StakeTableV3Events>),
+}
+
+// The generated sol event enums no longer derive `Debug`, but they do implement `Serialize`, so
+// render their contents as JSON.
+impl fmt::Debug for L1Event {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Reward(e) => write!(
+                f,
+                "Reward({})",
+                serde_json::to_string(e).unwrap_or_default()
+            ),
+            Self::StakeTable(e) => {
+                write!(
+                    f,
+                    "StakeTable({})",
+                    serde_json::to_string(e).unwrap_or_default()
+                )
+            }
+        }
+    }
 }
 
 impl From<RewardClaimEvents> for L1Event {
@@ -1214,24 +1283,41 @@ impl From<RewardClaimEvents> for L1Event {
     }
 }
 
-impl From<StakeTableV2Events> for L1Event {
-    fn from(event: StakeTableV2Events) -> Self {
+impl From<StakeTableV3Events> for L1Event {
+    fn from(event: StakeTableV3Events) -> Self {
         Self::StakeTable(Arc::new(event))
     }
 }
 
-impl From<&ValidatorRegistered> for NodeSetEntry {
-    fn from(e: &ValidatorRegistered) -> Self {
-        NodeSetEntry {
-            address: e.account,
-            staking_key: PubKey::from(e.blsVk).into(),
-            state_key: StateVerKey::from(e.schnorrVk).into(),
-            commission: Ratio::new(e.commission as usize, COMMISSION_BASIS_POINTS as usize),
-            // All nodes start with 0 stake, a separate delegation event will be generated when
-            // someone delegates non-zero stake to a node.
-            stake: ESPTokenAmount::ZERO,
-            metadata: None,
-        }
+/// Build a node set entry from already-parsed consensus keys.
+fn node_set_entry(
+    address: Address,
+    commission: u16,
+    staking_key: PubKey,
+    state_key: StateVerKey,
+) -> NodeSetEntry {
+    NodeSetEntry {
+        address,
+        staking_key: staking_key.into(),
+        state_key: state_key.into(),
+        commission: Ratio::new(commission as usize, COMMISSION_BASIS_POINTS as usize),
+        // All nodes start with 0 stake, a separate delegation event will be generated when someone
+        // delegates non-zero stake to a node.
+        stake: ESPTokenAmount::ZERO,
+        metadata: None,
+    }
+}
+
+impl TryFrom<&ValidatorRegistered> for NodeSetEntry {
+    type Error = StakeTableSolError;
+
+    fn try_from(e: &ValidatorRegistered) -> std::result::Result<Self, Self::Error> {
+        Ok(node_set_entry(
+            e.account,
+            e.commission,
+            PubKey::try_from(e.blsVk)?,
+            StateVerKey::try_from(e.schnorrVk)?,
+        ))
     }
 }
 
@@ -1309,11 +1395,12 @@ mod test {
         },
         types::common::{Address, NodeMetadataContent},
     };
-    use alloy::primitives::U256;
+    use alloy::primitives::{FixedBytes, U256};
     use espresso_types::{RegisteredValidatorMap, StakeTableState, v0_3::StakeTableEvent};
-    use hotshot_contract_adapter::sol_types::StakeTableV2::{
-        Delegated, ExitEscrowPeriodUpdated, MetadataUriUpdated, Undelegated, ValidatorExit,
-        ValidatorExitClaimed, ValidatorRegisteredV2, WithdrawalClaimed,
+    use hotshot_contract_adapter::sol_types::StakeTableV3::{
+        Delegated, ExitEscrowPeriodUpdated, MetadataUriUpdated, P2pAddrUpdated, Undelegated,
+        ValidatorExit, ValidatorExitClaimed, ValidatorRegisteredV2, WithdrawalClaimed,
+        X25519KeyUpdated,
     };
     use pretty_assertions::assert_eq;
     use reqwest::Url;
@@ -1327,10 +1414,11 @@ mod test {
     use crate::{
         input::l1::testing::{
             CatchupFromEvents, EventGenerator, InputGenerator, NoCatchup, block_snapshot,
-            subscribe_until, validator_registered_event,
+            subscribe_until, validator_registered_event, validator_registered_v3_event,
         },
         types::common::{Delegation, Ratio},
     };
+    use rand::{SeedableRng, rngs::StdRng};
 
     /// Generate a test [`State`] from a list of L1 blocks.
     fn from_blocks<S: Default, M: Default>(
@@ -1371,7 +1459,7 @@ mod test {
                 Ratio::new(validator.commission.into(), 10_000),
             );
             assert_eq!(node.stake, validator.stake);
-            assert_eq!(node.staking_key, validator.stake_table_key.into());
+            assert_eq!(node.staking_key, validator.stake_table_key.unwrap().into());
         }
     }
 
@@ -1537,6 +1625,118 @@ mod test {
     }
 
     #[test_log::test(tokio::test)]
+    async fn test_register_validator_v3() {
+        // Regression: StakeTableV3 introduced ValidatorRegisteredV3, X25519KeyUpdated, and
+        // P2pAddrUpdated events. The service previously only decoded StakeTableV2 events and
+        // panicked on any V3 event. A V3 registration must produce a node the same as V2, ignoring
+        // the x25519 key and p2p address.
+        let event = validator_registered_v3_event(StdRng::seed_from_u64(0));
+        let input = BlockInput::empty(1)
+            .with_event(StakeTableV3Events::ValidatorRegisteredV3(event.clone()));
+        let block = BlockData::empty(0).next(&NoMetadata, &input).await;
+
+        let node = block
+            .state
+            .node_set
+            .get(&event.account)
+            .expect("V3-registered node present in node set");
+        assert_eq!(node.address, event.account);
+        assert_eq!(
+            node.staking_key,
+            PubKey::try_from(event.blsVK).unwrap().into()
+        );
+        assert_eq!(
+            node.state_key,
+            StateVerKey::try_from(event.schnorrVK).unwrap().into()
+        );
+        assert_eq!(
+            node.commission,
+            Ratio::new(event.commission as usize, COMMISSION_BASIS_POINTS as usize),
+        );
+        assert_eq!(node.stake, ESPTokenAmount::ZERO);
+
+        // The V3-only X25519KeyUpdated and P2pAddrUpdated events carry networking data the service
+        // ignores. Applying them must not panic and must not change the node set.
+        let x25519 = BlockInput::empty(2).with_event(StakeTableV3Events::X25519KeyUpdated(
+            X25519KeyUpdated {
+                validator: event.account,
+                x25519Key: FixedBytes::<32>::with_last_byte(2),
+            },
+        ));
+        let p2p =
+            BlockInput::empty(3).with_event(StakeTableV3Events::P2pAddrUpdated(P2pAddrUpdated {
+                validator: event.account,
+                p2pAddr: "/ip4/127.0.0.1/tcp/5678".into(),
+            }));
+        let block = block.next(&NoMetadata, &x25519).await;
+        assert_eq!(block.node_set_update.as_deref(), Some(&[][..]));
+        let block = block.next(&NoMetadata, &p2p).await;
+        assert_eq!(block.node_set_update.as_deref(), Some(&[][..]));
+        assert_eq!(block.state.node_set.get(&event.account), Some(node));
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_register_validator_v2() {
+        // The V2 registration event predates V3 but stays in on-chain history, so it must still
+        // produce a node.
+        let event = validator_registered_event(StdRng::seed_from_u64(1));
+        let input = BlockInput::empty(1)
+            .with_event(StakeTableV3Events::ValidatorRegisteredV2(event.clone()));
+        let block = BlockData::empty(0).next(&NoMetadata, &input).await;
+
+        let node = block
+            .state
+            .node_set
+            .get(&event.account)
+            .expect("V2-registered node present in node set");
+        assert_eq!(
+            node.staking_key,
+            PubKey::try_from(event.blsVK).unwrap().into()
+        );
+        assert_eq!(
+            node.state_key,
+            StateVerKey::try_from(event.schnorrVK).unwrap().into()
+        );
+        assert_eq!(
+            node.commission,
+            Ratio::new(event.commission as usize, COMMISSION_BASIS_POINTS as usize),
+        );
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_register_validator_v1() {
+        // The original (V1) registration event has no signatures and predates V2/V3 but stays in
+        // on-chain history, so it must still produce a node.
+        let v2 = validator_registered_event(StdRng::seed_from_u64(2));
+        let event = ValidatorRegistered {
+            account: v2.account,
+            blsVk: v2.blsVK,
+            schnorrVk: v2.schnorrVK,
+            commission: v2.commission,
+        };
+        let input = BlockInput::empty(1).with_event(StakeTableV3Events::ValidatorRegistered(event));
+        let block = BlockData::empty(0).next(&NoMetadata, &input).await;
+
+        let node = block
+            .state
+            .node_set
+            .get(&event.account)
+            .expect("V1-registered node present in node set");
+        assert_eq!(
+            node.staking_key,
+            PubKey::try_from(event.blsVk).unwrap().into()
+        );
+        assert_eq!(
+            node.state_key,
+            StateVerKey::try_from(event.schnorrVk).unwrap().into()
+        );
+        assert_eq!(
+            node.commission,
+            Ratio::new(event.commission as usize, COMMISSION_BASIS_POINTS as usize),
+        );
+    }
+
+    #[test_log::test(tokio::test)]
     async fn test_replay_consistency() {
         let mut block = BlockData::empty(0);
         let mut state = StakeTableState::default();
@@ -1557,7 +1757,8 @@ mod test {
             for event in &input.events {
                 if let L1Event::StakeTable(e) = event {
                     let Ok(stake_table_event) = e.as_ref().clone().try_into() else {
-                        tracing::info!(?e, "skipping GCL-irrelevant contract event");
+                        let event = serde_json::to_string(e.as_ref()).unwrap();
+                        tracing::info!(%event, "skipping GCL-irrelevant contract event");
                         continue;
                     };
                     state.apply_event(stake_table_event).unwrap().unwrap();
@@ -1885,7 +2086,7 @@ mod test {
     /// * if an event is invalid, the state is not modified and no updates are recorded.
     async fn test_events(
         metadata_fetcher: &impl MetadataFetcher,
-        events: impl IntoIterator<Item = StakeTableV2Events>,
+        events: impl IntoIterator<Item = StakeTableV3Events>,
     ) -> BlockData {
         let mut curr = BlockData::empty(0);
         let mut stake_table = StakeTableState::default();
@@ -1928,7 +2129,7 @@ mod test {
         event.metadataUri = "".into();
         let block = test_events(
             &NoMetadata,
-            [StakeTableV2Events::ValidatorRegisteredV2(event.clone())],
+            [StakeTableV3Events::ValidatorRegisteredV2(event.clone())],
         )
         .await;
         let expected = NodeSetEntry::from_event_no_metadata(&event);
@@ -1949,7 +2150,7 @@ mod test {
 
         let block = test_events(
             &NoMetadata,
-            [StakeTableV2Events::ValidatorRegisteredV2(event)],
+            [StakeTableV3Events::ValidatorRegisteredV2(event)],
         )
         .await;
         assert_eq!(block.state.node_set.len(), 0);
@@ -1964,7 +2165,7 @@ mod test {
 
         let block = test_events(
             &NoMetadata,
-            [StakeTableV2Events::ValidatorRegisteredV2(event)],
+            [StakeTableV3Events::ValidatorRegisteredV2(event)],
         )
         .await;
         assert_eq!(block.state.node_set.len(), 0);
@@ -1976,8 +2177,8 @@ mod test {
         let next = test_events(
             &NoMetadata,
             [
-                StakeTableV2Events::ValidatorRegisteredV2(node.clone()),
-                StakeTableV2Events::ValidatorExit(ValidatorExit {
+                StakeTableV3Events::ValidatorRegisteredV2(node.clone()),
+                StakeTableV3Events::ValidatorExit(ValidatorExit {
                     validator: node.account,
                 }),
             ],
@@ -1997,7 +2198,7 @@ mod test {
     async fn test_event_validator_exit_invalid_not_found() {
         test_events(
             &NoMetadata,
-            [StakeTableV2Events::ValidatorExit(ValidatorExit {
+            [StakeTableV3Events::ValidatorExit(ValidatorExit {
                 validator: Address::random(),
             })],
         )
@@ -2010,7 +2211,7 @@ mod test {
         node.metadataUri = "".into();
         let block = test_events(
             &NoMetadata,
-            [StakeTableV2Events::ValidatorRegisteredV2(node.clone())],
+            [StakeTableV3Events::ValidatorRegisteredV2(node.clone())],
         )
         .await;
         assert_eq!(block.state.node_set[&node.account].metadata, None);
@@ -2021,8 +2222,8 @@ mod test {
         let mut node = validator_registered_event(rand::thread_rng());
         node.metadataUri = "https://testmetadata.com".to_string();
         let block: BlockData = test_events(
-            &ConstMetadata::with_key(node.blsVK.into()),
-            [StakeTableV2Events::ValidatorRegisteredV2(node.clone())],
+            &ConstMetadata::with_key(PubKey::try_from(node.blsVK).unwrap()),
+            [StakeTableV3Events::ValidatorRegisteredV2(node.clone())],
         )
         .await;
         assert_eq!(
@@ -2030,7 +2231,7 @@ mod test {
             Some(NodeMetadata {
                 uri: node.metadataUri.parse().unwrap(),
                 content: Some(NodeMetadataContent {
-                    pub_key: node.blsVK.into(),
+                    pub_key: PubKey::try_from(node.blsVK).unwrap(),
                     ..Default::default()
                 })
             })
@@ -2044,7 +2245,7 @@ mod test {
         let block: BlockData = test_events(
             // Use default metadata, not one with a public key corresponding to this node.
             &ConstMetadata::default(),
-            [StakeTableV2Events::ValidatorRegisteredV2(node.clone())],
+            [StakeTableV3Events::ValidatorRegisteredV2(node.clone())],
         )
         .await;
         assert_eq!(
@@ -2063,8 +2264,8 @@ mod test {
         let block = test_events(
             &ConstMetadata::default(),
             [
-                StakeTableV2Events::ValidatorRegisteredV2(node.clone()),
-                StakeTableV2Events::MetadataUriUpdated(MetadataUriUpdated {
+                StakeTableV3Events::ValidatorRegisteredV2(node.clone()),
+                StakeTableV3Events::MetadataUriUpdated(MetadataUriUpdated {
                     validator: node.account,
                     metadataUri: "".to_string(),
                 }),
@@ -2081,10 +2282,10 @@ mod test {
 
         let uri = "https://testmetadata.com";
         let block = test_events(
-            &ConstMetadata::with_key(node.blsVK.into()),
+            &ConstMetadata::with_key(PubKey::try_from(node.blsVK).unwrap()),
             [
-                StakeTableV2Events::ValidatorRegisteredV2(node.clone()),
-                StakeTableV2Events::MetadataUriUpdated(MetadataUriUpdated {
+                StakeTableV3Events::ValidatorRegisteredV2(node.clone()),
+                StakeTableV3Events::MetadataUriUpdated(MetadataUriUpdated {
                     validator: node.account,
                     metadataUri: uri.to_string(),
                 }),
@@ -2096,7 +2297,7 @@ mod test {
             Some(NodeMetadata {
                 uri: uri.parse().unwrap(),
                 content: Some(NodeMetadataContent {
-                    pub_key: node.blsVK.into(),
+                    pub_key: PubKey::try_from(node.blsVK).unwrap(),
                     ..Default::default()
                 })
             })
@@ -2113,8 +2314,8 @@ mod test {
             // Use default metadata, not one with a public key corresponding to this node.
             &ConstMetadata::default(),
             [
-                StakeTableV2Events::ValidatorRegisteredV2(node.clone()),
-                StakeTableV2Events::MetadataUriUpdated(MetadataUriUpdated {
+                StakeTableV3Events::ValidatorRegisteredV2(node.clone()),
+                StakeTableV3Events::MetadataUriUpdated(MetadataUriUpdated {
                     validator: node.account,
                     metadataUri: uri.to_string(),
                 }),
@@ -2134,7 +2335,7 @@ mod test {
     async fn test_exit_escrow_period_updated() {
         let block = test_events(
             &NoMetadata,
-            [StakeTableV2Events::ExitEscrowPeriodUpdated(
+            [StakeTableV3Events::ExitEscrowPeriodUpdated(
                 ExitEscrowPeriodUpdated {
                     newExitEscrowPeriod: 12345,
                 },
@@ -2151,13 +2352,13 @@ mod test {
         node.metadataUri = "".into();
 
         let input = BlockInput::empty(1)
-            .with_event(StakeTableV2Events::ValidatorRegisteredV2(node.clone()))
-            .with_event(StakeTableV2Events::ExitEscrowPeriodUpdated(
+            .with_event(StakeTableV3Events::ValidatorRegisteredV2(node.clone()))
+            .with_event(StakeTableV3Events::ExitEscrowPeriodUpdated(
                 ExitEscrowPeriodUpdated {
                     newExitEscrowPeriod: genesis.block().exit_escrow_period + 100,
                 },
             ))
-            .with_event(StakeTableV2Events::ValidatorExit(ValidatorExit {
+            .with_event(StakeTableV3Events::ValidatorExit(ValidatorExit {
                 validator: node.account,
             }));
         let block = genesis.next(&NoMetadata, &input).await;
@@ -2190,8 +2391,8 @@ mod test {
 
         // Register validator and delegate
         let events = vec![
-            StakeTableV2Events::ValidatorRegisteredV2(validator_reg.clone()),
-            StakeTableV2Events::Delegated(Delegated {
+            StakeTableV3Events::ValidatorRegisteredV2(validator_reg.clone()),
+            StakeTableV3Events::Delegated(Delegated {
                 delegator,
                 validator: validator_address,
                 amount: U256::from(1000),
@@ -2213,7 +2414,7 @@ mod test {
         let block2 = block1
             .next(
                 &NoMetadata,
-                &BlockInput::empty(2).with_event(StakeTableV2Events::Undelegated(Undelegated {
+                &BlockInput::empty(2).with_event(StakeTableV3Events::Undelegated(Undelegated {
                     delegator,
                     validator: validator_address,
                     amount: U256::from(400),
@@ -2243,7 +2444,7 @@ mod test {
         let block3 = block2
             .next(
                 &NoMetadata,
-                &BlockInput::empty(3).with_event(StakeTableV2Events::ValidatorExit(
+                &BlockInput::empty(3).with_event(StakeTableV3Events::ValidatorExit(
                     ValidatorExit {
                         validator: validator_address,
                     },
@@ -2273,7 +2474,7 @@ mod test {
         let block4 = block3
             .next(
                 &NoMetadata,
-                &BlockInput::empty(4).with_event(StakeTableV2Events::WithdrawalClaimed(
+                &BlockInput::empty(4).with_event(StakeTableV3Events::WithdrawalClaimed(
                     WithdrawalClaimed {
                         delegator,
                         validator: validator_address,
@@ -2298,7 +2499,7 @@ mod test {
         let block5 = block4
             .next(
                 &NoMetadata,
-                &BlockInput::empty(5).with_event(StakeTableV2Events::ValidatorExitClaimed(
+                &BlockInput::empty(5).with_event(StakeTableV3Events::ValidatorExitClaimed(
                     ValidatorExitClaimed {
                         delegator,
                         validator: validator_address,
@@ -2396,7 +2597,7 @@ mod test {
             .next(
                 &NoMetadata,
                 &BlockInput::empty(1)
-                    .with_event(StakeTableV2Events::ValidatorRegisteredV2(node.clone())),
+                    .with_event(StakeTableV3Events::ValidatorRegisteredV2(node.clone())),
             )
             .await;
         assert_eq!(
@@ -2411,7 +2612,7 @@ mod test {
         // blocks, we will refresh the node's metadata, which gives us another chance to load it
         // successfully.
         let content = NodeMetadataContent {
-            pub_key: node.blsVK.into(),
+            pub_key: PubKey::try_from(node.blsVK).unwrap(),
             name: Some("refreshed".into()),
             ..Default::default()
         };
@@ -2577,7 +2778,7 @@ mod test {
                 &fetcher,
                 block_id(METADATA_REFRESH_BLOCKS),
                 12 * METADATA_REFRESH_BLOCKS,
-                [&StakeTableV2Events::MetadataUriUpdated(MetadataUriUpdated {
+                [&StakeTableV3Events::MetadataUriUpdated(MetadataUriUpdated {
                     validator: node.address,
                     metadataUri: after.uri.to_string(),
                 })

--- a/src/input/l1/provider.rs
+++ b/src/input/l1/provider.rs
@@ -18,7 +18,7 @@ use alloy::{
 use hotshot_contract_adapter::sol_types::{
     EspToken,
     RewardClaim::RewardClaimEvents,
-    StakeTableV2::{self, StakeTableV2Events},
+    StakeTableV3::{self, StakeTableV3Events},
 };
 use tracing::instrument;
 
@@ -27,7 +27,7 @@ pub async fn load_genesis(
     provider: &impl Provider,
     stake_table: Address,
 ) -> Result<L1BlockSnapshot> {
-    let stake_table_contract = StakeTableV2::new(stake_table, provider);
+    let stake_table_contract = StakeTableV3::new(stake_table, provider);
 
     // Fetch the finalized block first.
     // This avoids a race condition where the initialized block could change
@@ -103,7 +103,7 @@ pub async fn get_initial_token_supply(
     chunk_size: u64,
 ) -> Result<ESPTokenAmount> {
     // Get the token contract from the stake table contract.
-    let stake_table_contract = StakeTableV2::new(stake_table, provider);
+    let stake_table_contract = StakeTableV3::new(stake_table, provider);
     let token_address =
         stake_table_contract.token().call().await.context(|| {
             Error::internal().context("getting token address from stake table contract")
@@ -278,7 +278,7 @@ pub(super) async fn get_events(
 
         // Try to decode stake table event
         if log.address() == stake_table_address {
-            let event = StakeTableV2Events::decode_raw_log(log.topics(), &log.data().data)
+            let event = StakeTableV3Events::decode_raw_log(log.topics(), &log.data().data)
                 .unwrap_or_else(|e| {
                     // This is a panic, not an error, as it should be impossible to successfully
                     // retrieve an event from the stake table address but not be able to decode it.
@@ -331,7 +331,7 @@ mod test {
 
     use crate::input::l1::testing::{
         ContractDeployment, DeploymentConfig, assert_events_eq,
-        validator_registered_event_with_account,
+        validator_registered_v3_event_with_account,
     };
 
     use super::*;
@@ -373,7 +373,7 @@ mod test {
             .connect_http(anvil.endpoint_url());
 
         let stake_table_address = deployment.stake_table_addr;
-        let contract = StakeTableV2::new(stake_table_address, &provider);
+        let contract = StakeTableV3::new(stake_table_address, &provider);
 
         // Change the exit escrow period, to verify that the genesis snapshot loads the exit escrow
         // period from the time when the contract was initialized, not what it is now.
@@ -429,21 +429,23 @@ mod test {
                     )
                     .connect_http(anvil.endpoint_url());
                 let address = provider.default_signer_address();
-                let node = validator_registered_event_with_account(
+                let node = validator_registered_v3_event_with_account(
                     StdRng::seed_from_u64(index as u64),
                     address,
                 );
-                let stake_table = StakeTableV2::new(deployment.stake_table_addr, provider.clone());
+                let stake_table = StakeTableV3::new(deployment.stake_table_addr, provider.clone());
                 tracing::info!(index, %address, "submitting registration");
                 async move {
                     let tx = stake_table
-                        .registerValidatorV2(
+                        .registerValidatorV3(
                             node.blsVK,
                             node.schnorrVK,
                             node.blsSig,
                             node.schnorrSig.clone(),
                             node.commission,
-                            "https://example.com/validator-metadata.json".to_string(),
+                            node.metadataUri.clone(),
+                            node.x25519Key,
+                            node.p2pAddr.clone(),
                         )
                         .send()
                         .await
@@ -454,7 +456,7 @@ mod test {
                     tracing::info!(index, "transaction mined");
 
                     let expected_event = L1Event::StakeTable(Arc::new(
-                        StakeTableV2Events::ValidatorRegisteredV2(node),
+                        StakeTableV3Events::ValidatorRegisteredV3(node),
                     ));
                     (receipt, expected_event)
                 }
@@ -580,7 +582,7 @@ mod test {
             .next()
             .unwrap()
             .1;
-        let stake_table_init_block = StakeTableV2::new(deployment.stake_table_addr, &provider)
+        let stake_table_init_block = StakeTableV3::new(deployment.stake_table_addr, &provider)
             .initializedAtBlock()
             .call()
             .await

--- a/src/input/l1/rpc_stream.rs
+++ b/src/input/l1/rpc_stream.rs
@@ -604,7 +604,7 @@ mod tests {
     use hotshot_contract_adapter::sol_types::StakeTableV3::{
         CommissionUpdated, ConsensusKeysUpdated, ConsensusKeysUpdatedV2, Delegated, Undelegated,
         UndelegatedV2, ValidatorExit, ValidatorExitClaimed, ValidatorExitV2, ValidatorRegistered,
-        ValidatorRegisteredV2, WithdrawalClaimed,
+        ValidatorRegisteredV2, ValidatorRegisteredV3, WithdrawalClaimed,
     };
     use staking_cli::demo::DelegationConfig;
     use std::time::Duration;
@@ -1089,6 +1089,7 @@ mod tests {
             .events([
                 ValidatorRegistered::SIGNATURE,
                 ValidatorRegisteredV2::SIGNATURE,
+                ValidatorRegisteredV3::SIGNATURE,
                 ValidatorExit::SIGNATURE,
                 ValidatorExitV2::SIGNATURE,
                 ValidatorExitClaimed::SIGNATURE,

--- a/src/input/l1/rpc_stream.rs
+++ b/src/input/l1/rpc_stream.rs
@@ -601,7 +601,7 @@ mod tests {
     use committable::Committable;
     use espresso_types::v0::StakeTableState;
     use futures::StreamExt;
-    use hotshot_contract_adapter::sol_types::StakeTableV2::{
+    use hotshot_contract_adapter::sol_types::StakeTableV3::{
         CommissionUpdated, ConsensusKeysUpdated, ConsensusKeysUpdatedV2, Delegated, Undelegated,
         UndelegatedV2, ValidatorExit, ValidatorExitClaimed, ValidatorExitV2, ValidatorRegistered,
         ValidatorRegisteredV2, WithdrawalClaimed,
@@ -949,7 +949,10 @@ mod tests {
             for event in &block_input.events {
                 match event {
                     L1Event::StakeTable(stake_event) => {
-                        println!("Stream event: {stake_event:?}");
+                        println!(
+                            "Stream event: {}",
+                            serde_json::to_string(stake_event.as_ref()).unwrap()
+                        );
                         if let Ok(event) = (**stake_event).clone().try_into() {
                             match stake_table_state_from_stream.apply_event(event) {
                                 Ok(Ok(())) => {}
@@ -1050,7 +1053,8 @@ mod tests {
                                 }
                             }
                         } else {
-                            tracing::info!(?event, "skipping irrelevant contract event");
+                            let event = serde_json::to_string(event.as_ref()).unwrap();
+                            tracing::info!(%event, "skipping irrelevant contract event");
                         }
                     }
                     L1Event::Reward(_) => {}
@@ -1250,11 +1254,11 @@ mod tests {
 
             assert_eq!(
                 node.staking_key.to_string(),
-                l1_validator.stake_table_key.to_string(),
+                l1_validator.stake_table_key.unwrap().to_string(),
                 "Staking key mismatch for validator {}: subscription={}, L1={}",
                 node.address,
                 node.staking_key,
-                l1_validator.stake_table_key
+                l1_validator.stake_table_key.unwrap()
             );
 
             let l1_commission_ratio = Ratio::new(l1_validator.commission as usize, 10_000);

--- a/src/input/l1/testing.rs
+++ b/src/input/l1/testing.rs
@@ -37,10 +37,10 @@ use hotshot_contract_adapter::{
     sol_types::{
         G1PointSol,
         RewardClaim::RewardsClaimed,
-        StakeTableV2::{
+        StakeTableV3::{
             self, CommissionUpdated, ConsensusKeysUpdatedV2, Delegated, ExitEscrowPeriodUpdated,
             MetadataUriUpdated, Undelegated, ValidatorExit, ValidatorExitClaimed,
-            ValidatorRegistered, ValidatorRegisteredV2, WithdrawalClaimed,
+            ValidatorRegistered, ValidatorRegisteredV2, ValidatorRegisteredV3, WithdrawalClaimed,
         },
     },
     stake_table::{StateSignatureSol, sign_address_bls, sign_address_schnorr},
@@ -50,11 +50,12 @@ use hotshot_types::{
     light_client::{StateKeyPair, StateVerKey, hash_bytes_to_field},
     signature_key::BLSKeyPair,
     traits::signature_key::{SignatureKey, StateSignatureKey},
+    x25519,
 };
 use jf_signature::{SignatureScheme, schnorr::SchnorrSignatureScheme};
 use pretty_assertions::assert_eq;
 use rand::{CryptoRng, Rng, RngCore, SeedableRng, rngs::StdRng, seq::IteratorRandom};
-use staking_cli::demo::{DelegationConfig, StakingTransactions};
+use staking_cli::demo::{DelegationConfig, StakingKeySet, StakingTransactions};
 use tide_disco::{Error as _, StatusCode, Url};
 use tokio::{task::spawn, time::sleep};
 
@@ -330,7 +331,7 @@ impl NodeSetEntry {
             commission: event.commission,
             schnorrVk: event.schnorrVK,
         };
-        (&legacy).into()
+        NodeSetEntry::try_from(&legacy).unwrap()
     }
 }
 
@@ -421,7 +422,7 @@ impl Iterator for EventGenerator {
                     self.commissions.insert(event.account, event.commission);
 
                     if t == REGISTER {
-                        StakeTableV2Events::ValidatorRegistered(ValidatorRegistered {
+                        StakeTableV3Events::ValidatorRegistered(ValidatorRegistered {
                             account: event.account,
                             blsVk: event.blsVK,
                             schnorrVk: event.schnorrVK,
@@ -429,7 +430,7 @@ impl Iterator for EventGenerator {
                         })
                         .into()
                     } else {
-                        StakeTableV2Events::ValidatorRegisteredV2(event).into()
+                        StakeTableV3Events::ValidatorRegisteredV2(event).into()
                     }
                 }
 
@@ -457,12 +458,12 @@ impl Iterator for EventGenerator {
                     self.nodes.remove(&node);
                     self.commissions.remove(&node);
                     self.exited_nodes.insert(node);
-                    StakeTableV2Events::ValidatorExit(ValidatorExit { validator: node }).into()
+                    StakeTableV3Events::ValidatorExit(ValidatorExit { validator: node }).into()
                 }
 
                 EXIT_ESCROW_PERIOD_UPDATED => {
                     // Set the exit escrow period to something random.
-                    StakeTableV2Events::ExitEscrowPeriodUpdated(ExitEscrowPeriodUpdated {
+                    StakeTableV3Events::ExitEscrowPeriodUpdated(ExitEscrowPeriodUpdated {
                         newExitEscrowPeriod: self.rng.next_u64(),
                     })
                     .into()
@@ -485,7 +486,7 @@ impl Iterator for EventGenerator {
                         .and_modify(|existing| *existing += amount)
                         .or_insert(amount);
 
-                    StakeTableV2Events::Delegated(Delegated {
+                    StakeTableV3Events::Delegated(Delegated {
                         delegator,
                         validator,
                         amount,
@@ -530,7 +531,7 @@ impl Iterator for EventGenerator {
 
                     self.pending_undelegations.insert(key, undelegate_amount);
 
-                    StakeTableV2Events::Undelegated(Undelegated {
+                    StakeTableV3Events::Undelegated(Undelegated {
                         delegator,
                         validator: node,
                         amount: undelegate_amount,
@@ -555,7 +556,7 @@ impl Iterator for EventGenerator {
                         let amount = self.pending_undelegations.remove(&key).unwrap();
                         let (delegator, validator) = key;
                         // undelegationId is not tracked in EventGenerator, use 0 as placeholder
-                        StakeTableV2Events::WithdrawalClaimed(WithdrawalClaimed {
+                        StakeTableV3Events::WithdrawalClaimed(WithdrawalClaimed {
                             delegator,
                             validator,
                             undelegationId: 0,
@@ -566,7 +567,7 @@ impl Iterator for EventGenerator {
                         let key = pending_exits[idx - pending_undelegations.len()];
                         let amount = self.pending_exits.remove(&key).unwrap();
                         let (delegator, validator) = key;
-                        StakeTableV2Events::ValidatorExitClaimed(ValidatorExitClaimed {
+                        StakeTableV3Events::ValidatorExitClaimed(ValidatorExitClaimed {
                             delegator,
                             validator,
                             amount,
@@ -591,7 +592,7 @@ impl Iterator for EventGenerator {
                     let schnorr_sig: StateSignatureSol =
                         sign_address_schnorr(&new_schnorr_key, node).into();
 
-                    StakeTableV2Events::ConsensusKeysUpdatedV2(ConsensusKeysUpdatedV2 {
+                    StakeTableV3Events::ConsensusKeysUpdatedV2(ConsensusKeysUpdatedV2 {
                         account: node,
                         blsVK: new_bls_key.ver_key().into(),
                         schnorrVK: new_schnorr_key.ver_key().into(),
@@ -608,7 +609,7 @@ impl Iterator for EventGenerator {
                     let new_commission = self.rng.gen_range(0..COMMISSION_BASIS_POINTS);
                     let old_commission = self.commissions.insert(node, new_commission).unwrap();
 
-                    StakeTableV2Events::CommissionUpdated(CommissionUpdated {
+                    StakeTableV3Events::CommissionUpdated(CommissionUpdated {
                         validator: node,
                         oldCommission: old_commission,
                         newCommission: new_commission,
@@ -639,7 +640,7 @@ impl Iterator for EventGenerator {
                     let Some(&node) = self.nodes.iter().choose(&mut self.rng) else {
                         continue;
                     };
-                    StakeTableV2Events::MetadataUriUpdated(MetadataUriUpdated {
+                    StakeTableV3Events::MetadataUriUpdated(MetadataUriUpdated {
                         validator: node,
                         metadataUri: random_metadata_uri(&mut self.rng),
                     })
@@ -691,6 +692,43 @@ pub fn validator_registered_event_with_account(
         blsSig: G1PointSol::from(bls_sig).into(),
         schnorrSig: StateSignatureSol::from(schnorr_sig).into(),
         metadataUri: random_metadata_uri(&mut rng),
+    }
+}
+
+/// Generate a valid [`ValidatorRegisteredV3`] event.
+pub fn validator_registered_v3_event(mut rng: impl RngCore + CryptoRng) -> ValidatorRegisteredV3 {
+    let mut address_bytes = FixedBytes::<32>::default();
+    rng.fill_bytes(address_bytes.as_mut_slice());
+    let account = Address::from_word(address_bytes);
+    validator_registered_v3_event_with_account(rng, account)
+}
+
+/// Generate a valid [`ValidatorRegisteredV3`] event for the given account.
+///
+/// The signatures cover the same fields as the V2 event, so the V2 generator is reused. The x25519
+/// key and p2p address use encodings the StakeTable V3 contract accepts, so the event can also drive
+/// an on-chain `registerValidatorV3` call.
+pub fn validator_registered_v3_event_with_account(
+    mut rng: impl RngCore + CryptoRng,
+    account: Address,
+) -> ValidatorRegisteredV3 {
+    let v2 = validator_registered_event_with_account(&mut rng, account);
+    let mut seed = [0u8; 32];
+    rng.fill_bytes(&mut seed);
+    let x25519_key = x25519::Keypair::generated_from_seed_indexed(seed, 0)
+        .unwrap()
+        .public_key()
+        .as_bytes();
+    ValidatorRegisteredV3 {
+        account: v2.account,
+        blsVK: v2.blsVK,
+        schnorrVK: v2.schnorrVK,
+        commission: v2.commission,
+        blsSig: v2.blsSig,
+        schnorrSig: v2.schnorrSig,
+        metadataUri: v2.metadataUri,
+        x25519Key: FixedBytes::<32>::from(x25519_key),
+        p2pAddr: "127.0.0.1:8080".into(),
     }
 }
 
@@ -932,9 +970,11 @@ impl ContractDeployment {
             })?;
 
         let mut contracts = Contracts::new();
-        args.deploy_all(&mut contracts).await.map_err(|err| {
-            Error::internal().context(format!("Failed to deploy contracts: {err}"))
-        })?;
+        args.deploy_to_stake_table_v3(&mut contracts)
+            .await
+            .map_err(|err| {
+                Error::internal().context(format!("Failed to deploy contracts: {err}"))
+            })?;
 
         let stake_table_addr = contracts
             .address(Contract::StakeTableProxy)
@@ -960,24 +1000,26 @@ impl ContractDeployment {
         })
     }
 
-    pub fn create_test_validators(
-        count: usize,
-    ) -> Vec<(PrivateKeySigner, BLSKeyPair, StateKeyPair)> {
+    pub fn create_test_validators(count: usize) -> Vec<StakingKeySet> {
         (0..count)
             .map(|i| {
                 let index = i as u32;
                 let seed = [index as u8; 32];
-                let signer = build_signer(DEV_MNEMONIC, index);
-                let bls_key_pair = BLSKeyPair::generate(&mut StdRng::from_seed(seed));
-                let state_key_pair = StateKeyPair::generate_from_seed_indexed(seed, index as u64);
-                (signer, bls_key_pair, state_key_pair)
+                StakingKeySet {
+                    signer: build_signer(DEV_MNEMONIC, index),
+                    bls: BLSKeyPair::generate(&mut StdRng::from_seed(seed)),
+                    state: StateKeyPair::generate_from_seed_indexed(seed, index as u64),
+                    x25519: x25519::Keypair::generated_from_seed_indexed(seed, index as u64)
+                        .unwrap(),
+                    p2p_addr: "127.0.0.1:8080".parse().unwrap(),
+                }
             })
             .collect()
     }
 
     pub async fn register_validators(
         &self,
-        validators: Vec<(PrivateKeySigner, BLSKeyPair, StateKeyPair)>,
+        validators: Vec<StakingKeySet>,
         delegation_config: DelegationConfig,
     ) -> Result<Vec<TransactionReceipt>> {
         let provider = ProviderBuilder::new()
@@ -1109,7 +1151,14 @@ impl BackgroundTaskState {
             self.rpc_url.clone(),
             &provider,
             self.stake_table_addr,
-            vec![(signer.clone(), bls_key.clone(), schnorr_key.clone())],
+            vec![StakingKeySet {
+                signer: signer.clone(),
+                bls: bls_key.clone(),
+                state: schnorr_key.clone(),
+                x25519: x25519::Keypair::generated_from_seed_indexed(seed, self.validator_index)
+                    .unwrap(),
+                p2p_addr: "127.0.0.1:8080".parse().unwrap(),
+            }],
             None,
             DelegationConfig::MultipleDelegators,
         )
@@ -1204,7 +1253,7 @@ impl BackgroundTaskState {
             sign_address_schnorr(&new_schnorr_key, validator.address).into();
 
         tracing::debug!(signer = %validator.provider.default_signer_address(), "update keys");
-        match StakeTableV2::new(self.stake_table_addr, &validator.provider)
+        match StakeTableV3::new(self.stake_table_addr, &validator.provider)
             .updateConsensusKeysV2(
                 new_bls_key.ver_key().into(),
                 new_schnorr_key.ver_key().into(),
@@ -1254,7 +1303,7 @@ impl BackgroundTaskState {
         }
 
         let provider = ProviderBuilder::new().connect_http(self.rpc_url.clone());
-        let stake_table = StakeTableV2::new(self.stake_table_addr, &provider);
+        let stake_table = StakeTableV3::new(self.stake_table_addr, &provider);
 
         if let Ok(delegated_amount) = stake_table
             .delegations(validator.address, delegator.address)
@@ -1268,7 +1317,7 @@ impl BackgroundTaskState {
                 signer = %delegator.provider.default_signer_address(),
                 "undelegate"
             );
-            match StakeTableV2::new(self.stake_table_addr, &delegator.provider)
+            match StakeTableV3::new(self.stake_table_addr, &delegator.provider)
                 .undelegate(validator.address, undelegate_amount)
                 .send()
                 .await
@@ -1307,7 +1356,7 @@ impl BackgroundTaskState {
         let validator = &self.registered_validators[idx];
 
         tracing::debug!(signer = %validator.provider.default_signer_address(), "deregister");
-        match StakeTableV2::new(self.stake_table_addr, &validator.provider)
+        match StakeTableV3::new(self.stake_table_addr, &validator.provider)
             .deregisterValidator()
             .send()
             .await
@@ -1363,12 +1412,12 @@ impl BackgroundTaskState {
         if let Some(provider) = self.delegator_providers.get(&delegator_addr) {
             tracing::debug!(signer = %provider.default_signer_address(), "withdraw");
             let result = if is_exit {
-                StakeTableV2::new(self.stake_table_addr, &provider)
+                StakeTableV3::new(self.stake_table_addr, &provider)
                     .claimValidatorExit(validator_addr)
                     .send()
                     .await
             } else {
-                StakeTableV2::new(self.stake_table_addr, &provider)
+                StakeTableV3::new(self.stake_table_addr, &provider)
                     .claimWithdrawal(validator_addr)
                     .send()
                     .await
@@ -1447,8 +1496,8 @@ pub fn assert_events_eq(l: &L1Event, r: &L1Event) {
     match (l, r) {
         (L1Event::StakeTable(l), L1Event::StakeTable(r)) => match (l.as_ref(), r.as_ref()) {
             (
-                StakeTableV2Events::ValidatorRegistered(l),
-                StakeTableV2Events::ValidatorRegistered(r),
+                StakeTableV3Events::ValidatorRegistered(l),
+                StakeTableV3Events::ValidatorRegistered(r),
             ) => {
                 assert_eq!(l.account, r.account);
                 assert_eq!(l.blsVk, r.blsVk);
@@ -1456,113 +1505,126 @@ pub fn assert_events_eq(l: &L1Event, r: &L1Event) {
                 assert_eq!(l.commission, r.commission);
             }
             (
-                StakeTableV2Events::ValidatorRegisteredV2(l),
-                StakeTableV2Events::ValidatorRegisteredV2(r),
+                StakeTableV3Events::ValidatorRegisteredV2(l),
+                StakeTableV3Events::ValidatorRegisteredV2(r),
             ) => {
                 assert_eq!(l.account, r.account);
                 assert_eq!(l.blsVK, r.blsVK);
                 assert_eq!(l.schnorrVK, r.schnorrVK);
                 assert_eq!(l.commission, r.commission);
             }
-            (StakeTableV2Events::ValidatorExit(l), StakeTableV2Events::ValidatorExit(r)) => {
+            (
+                StakeTableV3Events::ValidatorRegisteredV3(l),
+                StakeTableV3Events::ValidatorRegisteredV3(r),
+            ) => {
+                assert_eq!(l.account, r.account);
+                assert_eq!(l.blsVK, r.blsVK);
+                assert_eq!(l.schnorrVK, r.schnorrVK);
+                assert_eq!(l.commission, r.commission);
+                assert_eq!(l.x25519Key, r.x25519Key);
+                assert_eq!(l.p2pAddr, r.p2pAddr);
+            }
+            (StakeTableV3Events::ValidatorExit(l), StakeTableV3Events::ValidatorExit(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::ValidatorExitV2(l), StakeTableV2Events::ValidatorExitV2(r)) => {
+            (StakeTableV3Events::ValidatorExitV2(l), StakeTableV3Events::ValidatorExitV2(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::Delegated(l), StakeTableV2Events::Delegated(r)) => {
+            (StakeTableV3Events::Delegated(l), StakeTableV3Events::Delegated(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::Undelegated(l), StakeTableV2Events::Undelegated(r)) => {
+            (StakeTableV3Events::Undelegated(l), StakeTableV3Events::Undelegated(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::UndelegatedV2(l), StakeTableV2Events::UndelegatedV2(r)) => {
+            (StakeTableV3Events::UndelegatedV2(l), StakeTableV3Events::UndelegatedV2(r)) => {
                 assert_eq!(l, r);
             }
             (
-                StakeTableV2Events::ConsensusKeysUpdated(l),
-                StakeTableV2Events::ConsensusKeysUpdated(r),
+                StakeTableV3Events::ConsensusKeysUpdated(l),
+                StakeTableV3Events::ConsensusKeysUpdated(r),
             ) => {
                 assert_eq!(l.account, r.account);
                 assert_eq!(l.blsVK, r.blsVK);
                 assert_eq!(l.schnorrVK, r.schnorrVK);
             }
             (
-                StakeTableV2Events::ConsensusKeysUpdatedV2(l),
-                StakeTableV2Events::ConsensusKeysUpdatedV2(r),
+                StakeTableV3Events::ConsensusKeysUpdatedV2(l),
+                StakeTableV3Events::ConsensusKeysUpdatedV2(r),
             ) => {
                 assert_eq!(l.account, r.account);
                 assert_eq!(l.blsVK, r.blsVK);
                 assert_eq!(l.schnorrVK, r.schnorrVK);
             }
             (
-                StakeTableV2Events::CommissionUpdated(l),
-                StakeTableV2Events::CommissionUpdated(r),
+                StakeTableV3Events::CommissionUpdated(l),
+                StakeTableV3Events::CommissionUpdated(r),
             ) => {
                 assert_eq!(l, r);
             }
             (
-                StakeTableV2Events::ExitEscrowPeriodUpdated(l),
-                StakeTableV2Events::ExitEscrowPeriodUpdated(r),
+                StakeTableV3Events::ExitEscrowPeriodUpdated(l),
+                StakeTableV3Events::ExitEscrowPeriodUpdated(r),
             ) => {
                 assert_eq!(l, r);
             }
             (
-                StakeTableV2Events::MaxCommissionIncreaseUpdated(l),
-                StakeTableV2Events::MaxCommissionIncreaseUpdated(r),
+                StakeTableV3Events::MaxCommissionIncreaseUpdated(l),
+                StakeTableV3Events::MaxCommissionIncreaseUpdated(r),
             ) => {
                 assert_eq!(l, r);
             }
             (
-                StakeTableV2Events::MinCommissionUpdateIntervalUpdated(l),
-                StakeTableV2Events::MinCommissionUpdateIntervalUpdated(r),
+                StakeTableV3Events::MinCommissionUpdateIntervalUpdated(l),
+                StakeTableV3Events::MinCommissionUpdateIntervalUpdated(r),
             ) => {
                 assert_eq!(l, r);
             }
             (
-                StakeTableV2Events::OwnershipTransferred(l),
-                StakeTableV2Events::OwnershipTransferred(r),
+                StakeTableV3Events::OwnershipTransferred(l),
+                StakeTableV3Events::OwnershipTransferred(r),
             ) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::Paused(l), StakeTableV2Events::Paused(r)) => {
+            (StakeTableV3Events::Paused(l), StakeTableV3Events::Paused(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::Unpaused(l), StakeTableV2Events::Unpaused(r)) => {
+            (StakeTableV3Events::Unpaused(l), StakeTableV3Events::Unpaused(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::Initialized(l), StakeTableV2Events::Initialized(r)) => {
+            (StakeTableV3Events::Initialized(l), StakeTableV3Events::Initialized(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::RoleAdminChanged(l), StakeTableV2Events::RoleAdminChanged(r)) => {
+            (StakeTableV3Events::RoleAdminChanged(l), StakeTableV3Events::RoleAdminChanged(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::RoleGranted(l), StakeTableV2Events::RoleGranted(r)) => {
+            (StakeTableV3Events::RoleGranted(l), StakeTableV3Events::RoleGranted(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::RoleRevoked(l), StakeTableV2Events::RoleRevoked(r)) => {
+            (StakeTableV3Events::RoleRevoked(l), StakeTableV3Events::RoleRevoked(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::Upgraded(l), StakeTableV2Events::Upgraded(r)) => {
+            (StakeTableV3Events::Upgraded(l), StakeTableV3Events::Upgraded(r)) => {
                 assert_eq!(l, r);
             }
-            (StakeTableV2Events::Withdrawal(l), StakeTableV2Events::Withdrawal(r)) => {
+            (StakeTableV3Events::Withdrawal(l), StakeTableV3Events::Withdrawal(r)) => {
                 assert_eq!(l, r);
             }
             (
-                StakeTableV2Events::WithdrawalClaimed(l),
-                StakeTableV2Events::WithdrawalClaimed(r),
+                StakeTableV3Events::WithdrawalClaimed(l),
+                StakeTableV3Events::WithdrawalClaimed(r),
             ) => {
                 assert_eq!(l, r);
             }
             (
-                StakeTableV2Events::ValidatorExitClaimed(l),
-                StakeTableV2Events::ValidatorExitClaimed(r),
+                StakeTableV3Events::ValidatorExitClaimed(l),
+                StakeTableV3Events::ValidatorExitClaimed(r),
             ) => {
                 assert_eq!(l, r);
             }
             (l, r) => {
-                panic!("mismatched stake table events:\n{l:#?}\n{r:#?}",);
+                let l = serde_json::to_string_pretty(l).unwrap();
+                let r = serde_json::to_string_pretty(r).unwrap();
+                panic!("mismatched stake table events:\n{l}\n{r}");
             }
         },
         (L1Event::Reward(l), L1Event::Reward(r)) => {


### PR DESCRIPTION
Bump espresso-network deps 20260414 -> 20260707 and handle the breaking changes it brings:

- Decode stake table logs as StakeTableV3Events (superset of V2). Handle ValidatorRegisteredV3 like V2; ignore the new networking-only X25519KeyUpdated and P2pAddrUpdated events.
- Key conversions became fallible (TryFrom): the all-zero G2 point that Solidity emits is off-curve. Registration and ConsensusKeysUpdatedV2 reuse keys from authenticate(); V1 arms try_from and skip on error instead of panicking.
- AuthenticatedValidator.stake_table_key is now Option; use the stake_table_key() accessor.
- Unify bitvec on the EspressoSystems fork so serde is available.
- Manual Debug for L1Event (sol enums dropped the derive).
