### PR TITLE
Use undelegation_id to track pending undelegations

### DIFF
--- a/api/api.toml
+++ b/api/api.toml
@@ -96,10 +96,16 @@ A representation of short binary strings consisting of:
 {
     "delegator": Hex,
     "node": Hex,
+    "undelegation_id": integer,
     "amount": BigInt,
     "available_time": integer
 }
 ```
+
+`undelegation_id` is the ID the stake table contract assigned to the undelegation. It distinguishes
+multiple pending undelegations from the same node; a `Withdrawal` completing one of them carries the
+same ID. Undelegations created by the V1 contract have ID 0, as do pending withdrawals caused by a
+node exit rather than an undelegation.
 
 ### `Withdrawal`
 
@@ -107,9 +113,13 @@ A representation of short binary strings consisting of:
 {
     "delegator": Hex,
     "node": Hex,
+    "undelegation_id": integer,
     "amount": BigInt
 }
 ```
+
+`undelegation_id` identifies the pending undelegation this withdrawal completes. Always 0 for
+withdrawals of stake released by a node exit.
 """
 
 [route.l1_block_latest]

--- a/migrations/sqlite/01_init_schema.sql
+++ b/migrations/sqlite/01_init_schema.sql
@@ -41,10 +41,11 @@ CREATE INDEX delegation_by_node ON delegation (node);
 CREATE TABLE pending_withdrawals (
     delegator TEXT NOT NULL REFERENCES wallet (address),
     node TEXT NOT NULL,
+    undelegation_id BIGINT NOT NULL,
     withdrawal_type TEXT NOT NULL CHECK(withdrawal_type IN ('undelegation', 'exit')),
     amount TEXT NOT NULL,
     unlocks_at BIGINT NOT NULL,
-    PRIMARY KEY (delegator, node, withdrawal_type)
+    PRIMARY KEY (delegator, node, withdrawal_type, undelegation_id)
 );
 
 -- Rewards

--- a/src/input/l1.rs
+++ b/src/input/l1.rs
@@ -753,6 +753,7 @@ impl Snapshot {
                                 let pending_exit = PendingWithdrawal {
                                     delegator: *wallet_address,
                                     node: validator,
+                                    undelegation_id: 0,
                                     amount: delegation.amount,
                                     available_time: exit_time,
                                 };
@@ -872,16 +873,22 @@ impl Snapshot {
                 }
                 ev
                 @ (StakeTableV3Events::Undelegated(_) | StakeTableV3Events::UndelegatedV2(_)) => {
-                    let (validator, delegator, amount, available_time) = match ev {
+                    // V1 undelegations have no ID. The contract identifies them as ID 0
+                    let (validator, delegator, undelegation_id, amount, available_time) = match ev {
                         StakeTableV3Events::Undelegated(e) => (
                             e.validator,
                             e.delegator,
+                            0,
                             e.amount,
                             timestamp + self.block.exit_escrow_period,
                         ),
-                        StakeTableV3Events::UndelegatedV2(e) => {
-                            (e.validator, e.delegator, e.amount, e.unlocksAt.to::<u64>())
-                        }
+                        StakeTableV3Events::UndelegatedV2(e) => (
+                            e.validator,
+                            e.delegator,
+                            e.undelegationId,
+                            e.amount,
+                            e.unlocksAt.to::<u64>(),
+                        ),
                         _ => unreachable!(),
                     };
 
@@ -897,6 +904,7 @@ impl Snapshot {
                     let pending_withdrawal = PendingWithdrawal {
                         delegator,
                         node: validator,
+                        undelegation_id,
                         amount,
                         available_time,
                     };
@@ -927,16 +935,20 @@ impl Snapshot {
                         )
                     });
 
-                    if !wallet.pending_undelegations.contains_key(&ev.validator) {
+                    if !wallet
+                        .pending_undelegations
+                        .contains_key(&(ev.validator, ev.undelegationId))
+                    {
                         panic!(
-                            "got WithdrawalClaimed but no pending undelegation for delegator {} validator {} amount {}",
-                            ev.delegator, ev.validator, ev.amount
+                            "got WithdrawalClaimed but no pending undelegation for delegator {} validator {} id {} amount {}",
+                            ev.delegator, ev.validator, ev.undelegationId, ev.amount
                         );
                     }
 
                     let withdrawal = Withdrawal {
                         delegator: ev.delegator,
                         node: ev.validator,
+                        undelegation_id: ev.undelegationId,
                         amount: ev.amount,
                     };
                     let wallet_diff = WalletDiff::UndelegationWithdrawal(withdrawal);
@@ -960,6 +972,7 @@ impl Snapshot {
                     let withdrawal = Withdrawal {
                         delegator: ev.delegator,
                         node: ev.validator,
+                        undelegation_id: 0,
                         amount: ev.amount,
                     };
                     let wallet_diff = WalletDiff::NodeExitWithdrawal(withdrawal);
@@ -1092,7 +1105,12 @@ pub struct Wallet {
     pub nodes: im::OrdMap<Address, Delegation>,
 
     /// Stake that has been undelegated but not yet withdrawn.
-    pub pending_undelegations: im::OrdMap<Address, PendingWithdrawal>,
+    ///
+    /// Keyed by node address and undelegation ID, since a wallet can have several concurrent
+    /// pending undelegations from the same node (e.g. batched calls in a single multisig
+    /// transaction). The ID alone is not unique across the map: undelegations created by the V1
+    /// contract all have ID 0, and are distinguished by node.
+    pub pending_undelegations: im::OrdMap<(Address, u64), PendingWithdrawal>,
 
     /// Stake previously delegated to nodes that have exited.
     pub pending_exits: im::OrdMap<Address, PendingWithdrawal>,
@@ -1156,10 +1174,13 @@ impl Wallet {
                 // Add to pending undelegations
                 if self
                     .pending_undelegations
-                    .insert(pending.node, *pending)
+                    .insert((pending.node, pending.undelegation_id), *pending)
                     .is_some()
                 {
-                    panic!("attempted to add duplicate pending undelegation for node {node}");
+                    panic!(
+                        "attempted to add duplicate pending undelegation {} for node {node}",
+                        pending.undelegation_id
+                    );
                 }
             }
             WalletDiff::NodeExited(pending) => {
@@ -1174,13 +1195,16 @@ impl Wallet {
             WalletDiff::UndelegationWithdrawal(withdrawal) => {
                 // Remove from pending undelegations
                 let node = withdrawal.node;
+                let id = withdrawal.undelegation_id;
                 let amount = withdrawal.amount;
                 if self
                     .pending_undelegations
-                    .remove(&withdrawal.node)
+                    .remove(&(withdrawal.node, withdrawal.undelegation_id))
                     .is_none()
                 {
-                    panic!("attempted to withdraw undelegation from node {node} amount: {amount}");
+                    panic!(
+                        "attempted to withdraw undelegation {id} from node {node} amount: {amount}"
+                    );
                 }
             }
             WalletDiff::NodeExitWithdrawal(withdrawal) => {
@@ -1400,8 +1424,8 @@ mod test {
     use espresso_types::{RegisteredValidatorMap, StakeTableState, v0_3::StakeTableEvent};
     use hotshot_contract_adapter::sol_types::StakeTableV3::{
         Delegated, ExitEscrowPeriodUpdated, MetadataUriUpdated, P2pAddrUpdated, Undelegated,
-        ValidatorExit, ValidatorExitClaimed, ValidatorRegisteredV2, WithdrawalClaimed,
-        X25519KeyUpdated,
+        UndelegatedV2, ValidatorExit, ValidatorExitClaimed, ValidatorRegisteredV2,
+        WithdrawalClaimed, X25519KeyUpdated,
     };
     use pretty_assertions::assert_eq;
     use reqwest::Url;
@@ -2434,7 +2458,7 @@ mod test {
         assert_eq!(
             wallet
                 .pending_undelegations
-                .get(&validator_address)
+                .get(&(validator_address, 0))
                 .unwrap()
                 .amount,
             U256::from(400)
@@ -2460,7 +2484,7 @@ mod test {
         assert_eq!(
             wallet
                 .pending_undelegations
-                .get(&validator_address)
+                .get(&(validator_address, 0))
                 .unwrap()
                 .amount,
             U256::from(400)
@@ -2514,6 +2538,116 @@ mod test {
         assert_eq!(wallet.nodes.len(), 0);
         assert_eq!(wallet.pending_undelegations.len(), 0);
         assert_eq!(wallet.pending_exits.len(), 0);
+    }
+
+    // Two undelegations from the same validator can be pending at the same time, e.g. batched
+    // calls in a single multisig transaction. They are distinguished by undelegation ID.
+    #[test_log::test(tokio::test)]
+    async fn test_concurrent_undelegations_from_same_validator() {
+        let delegator = Address::random();
+
+        let validator_reg = validator_registered_event(rand::thread_rng());
+        let validator_address = validator_reg.account;
+
+        let events = vec![
+            StakeTableV3Events::ValidatorRegisteredV2(validator_reg),
+            StakeTableV3Events::Delegated(Delegated {
+                delegator,
+                validator: validator_address,
+                amount: U256::from(1000),
+            }),
+        ];
+        let block1 = test_events(&NoMetadata, events).await;
+
+        // Two undelegations from the same validator in the same block (one transaction).
+        let block2 = block1
+            .next(
+                &NoMetadata,
+                &BlockInput::empty(3)
+                    .with_event(StakeTableV3Events::UndelegatedV2(UndelegatedV2 {
+                        delegator,
+                        validator: validator_address,
+                        undelegationId: 7,
+                        amount: U256::from(400),
+                        unlocksAt: U256::from(5000),
+                    }))
+                    .with_event(StakeTableV3Events::UndelegatedV2(UndelegatedV2 {
+                        delegator,
+                        validator: validator_address,
+                        undelegationId: 8,
+                        amount: U256::from(100),
+                        unlocksAt: U256::from(6000),
+                    })),
+            )
+            .await;
+
+        // Both undelegations are pending, tracked separately by ID.
+        let wallet = block2.state.wallets.get(&delegator).unwrap();
+        assert_eq!(
+            wallet.nodes.get(&validator_address).unwrap().amount,
+            U256::from(500)
+        );
+        assert_eq!(wallet.pending_undelegations.len(), 2);
+        let first = wallet
+            .pending_undelegations
+            .get(&(validator_address, 7))
+            .unwrap();
+        assert_eq!(first.amount, U256::from(400));
+        assert_eq!(first.available_time, 5000);
+        let second = wallet
+            .pending_undelegations
+            .get(&(validator_address, 8))
+            .unwrap();
+        assert_eq!(second.amount, U256::from(100));
+        assert_eq!(second.available_time, 6000);
+        assert_eq!(
+            block2.state.node_set.get(&validator_address).unwrap().stake,
+            U256::from(500)
+        );
+
+        // Claiming one undelegation removes exactly that one.
+        let block3 = block2
+            .next(
+                &NoMetadata,
+                &BlockInput::empty(4).with_event(StakeTableV3Events::WithdrawalClaimed(
+                    WithdrawalClaimed {
+                        delegator,
+                        validator: validator_address,
+                        undelegationId: 7,
+                        amount: U256::from(400),
+                    },
+                )),
+            )
+            .await;
+
+        let wallet = block3.state.wallets.get(&delegator).unwrap();
+        assert_eq!(wallet.pending_undelegations.len(), 1);
+        assert_eq!(
+            wallet
+                .pending_undelegations
+                .get(&(validator_address, 8))
+                .unwrap()
+                .amount,
+            U256::from(100)
+        );
+
+        // Claiming the other leaves none.
+        let block4 = block3
+            .next(
+                &NoMetadata,
+                &BlockInput::empty(5).with_event(StakeTableV3Events::WithdrawalClaimed(
+                    WithdrawalClaimed {
+                        delegator,
+                        validator: validator_address,
+                        undelegationId: 8,
+                        amount: U256::from(100),
+                    },
+                )),
+            )
+            .await;
+
+        let wallet = block4.state.wallets.get(&delegator).unwrap();
+        assert_eq!(wallet.pending_undelegations.len(), 0);
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/src/persistence/sql.rs
+++ b/src/persistence/sql.rs
@@ -45,6 +45,9 @@ pub struct PersistenceOptions {
     pub max_connections: u32,
 }
 
+/// A `pending_withdrawals` row: node, undelegation ID, withdrawal type, amount, and unlock time.
+type PendingWithdrawalRow = (String, i64, String, String, i64);
+
 #[derive(Debug, Clone)]
 pub struct Persistence {
     pool: SqlitePool,
@@ -164,8 +167,9 @@ impl Persistence {
         .fetch_all(tx.as_mut())
         .await?;
 
-        let all_pending = sqlx::query_as::<_, (String, String, String, String, i64)>(
-            "SELECT delegator, node, withdrawal_type, amount, unlocks_at FROM pending_withdrawals",
+        let all_pending = sqlx::query_as::<_, (String, String, i64, String, String, i64)>(
+            "SELECT delegator, node, undelegation_id, withdrawal_type, amount, unlocks_at
+             FROM pending_withdrawals",
         )
         .fetch_all(tx.as_mut())
         .await?;
@@ -178,11 +182,11 @@ impl Persistence {
                 .push((node, amount));
         }
 
-        let mut pending_by_wallet: HashMap<String, Vec<(String, String, String, i64)>> =
-            HashMap::new();
-        for (delegator, node, withdrawal_type, amount, unlocks_at) in all_pending {
+        let mut pending_by_wallet: HashMap<String, Vec<PendingWithdrawalRow>> = HashMap::new();
+        for (delegator, node, undelegation_id, withdrawal_type, amount, unlocks_at) in all_pending {
             pending_by_wallet.entry(delegator).or_default().push((
                 node,
+                undelegation_id,
                 withdrawal_type,
                 amount,
                 unlocks_at,
@@ -217,7 +221,9 @@ impl Persistence {
             let mut pending_undelegations = im::OrdMap::new();
             let mut pending_exits = im::OrdMap::new();
             if let Some(pending_rows) = pending_by_wallet.remove(&wallet_address) {
-                for (node_str, withdrawal_type_str, amount_str, available_time) in pending_rows {
+                for (node_str, undelegation_id, withdrawal_type_str, amount_str, available_time) in
+                    pending_rows
+                {
                     let node: Address = node_str.parse().context("failed to parse node address")?;
                     let amount =
                         U256::from_str(&amount_str).context("failed to parse pending amount")?;
@@ -226,13 +232,15 @@ impl Persistence {
                     let withdrawal = PendingWithdrawal {
                         delegator: address,
                         node,
+                        undelegation_id: undelegation_id as u64,
                         amount,
                         available_time: available_time as u64,
                     };
 
                     match withdrawal_type {
                         WithdrawalType::Undelegation => {
-                            pending_undelegations.insert(node, withdrawal);
+                            pending_undelegations
+                                .insert((node, withdrawal.undelegation_id), withdrawal);
                         }
                         WithdrawalType::Exit => {
                             pending_exits.insert(node, withdrawal);
@@ -459,13 +467,14 @@ impl Persistence {
                 }
 
                 // Insert pending undelegation
-                // we expect this to fail if there's already a pending undelegation
+                // we expect this to fail if there's already a pending undelegation with this ID
                 sqlx::query(
-                    "INSERT INTO pending_withdrawals (delegator, node, withdrawal_type, amount, unlocks_at)
-                     VALUES ($1, $2, $3, $4, $5)",
+                    "INSERT INTO pending_withdrawals (delegator, node, undelegation_id, withdrawal_type, amount, unlocks_at)
+                     VALUES ($1, $2, $3, $4, $5, $6)",
                 )
                 .bind(withdrawal.delegator.to_string())
                 .bind(withdrawal.node.to_string())
+                .bind(withdrawal.undelegation_id as i64)
                 .bind(String::from(WithdrawalType::Undelegation))
                 .bind(withdrawal.amount.to_string())
                 .bind(withdrawal.available_time as i64)
@@ -494,11 +503,12 @@ impl Persistence {
                 // Insert pending exit with the amount from the withdrawal
                 // we expect this to fail if there is already a pending exit
                 sqlx::query(
-                    "INSERT INTO pending_withdrawals (delegator, node, withdrawal_type, amount, unlocks_at)
-                     VALUES ($1, $2, $3, $4, $5)",
+                    "INSERT INTO pending_withdrawals (delegator, node, undelegation_id, withdrawal_type, amount, unlocks_at)
+                     VALUES ($1, $2, $3, $4, $5, $6)",
                 )
                 .bind(withdrawal.delegator.to_string())
                 .bind(withdrawal.node.to_string())
+                .bind(withdrawal.undelegation_id as i64)
                 .bind(String::from(WithdrawalType::Exit))
                 .bind(withdrawal.amount.to_string())
                 .bind(withdrawal.available_time as i64)
@@ -509,10 +519,12 @@ impl Persistence {
                 // Delete the pending undelegation withdrawal
                 let result = sqlx::query(
                     "DELETE FROM pending_withdrawals
-                     WHERE delegator = $1 AND node = $2 AND withdrawal_type = 'undelegation'",
+                     WHERE delegator = $1 AND node = $2 AND undelegation_id = $3
+                       AND withdrawal_type = 'undelegation'",
                 )
                 .bind(withdrawal.delegator.to_string())
                 .bind(withdrawal.node.to_string())
+                .bind(withdrawal.undelegation_id as i64)
                 .execute(&mut **tx)
                 .await?;
 
@@ -1139,6 +1151,7 @@ mod tests {
                     WalletDiff::UndelegatedFromNode(PendingWithdrawal {
                         delegator: delegator1,
                         node: node1.address,
+                        undelegation_id: 1,
                         amount: U256::from(1000000u64),
                         available_time: 800,
                     }),
@@ -1146,6 +1159,7 @@ mod tests {
                     WalletDiff::UndelegationWithdrawal(Withdrawal {
                         delegator: delegator1,
                         node: node1.address,
+                        undelegation_id: 1,
                         amount: U256::from(1000000u64),
                     }),
                     // Delegator1 claims rewards
@@ -1171,6 +1185,7 @@ mod tests {
                     WalletDiff::UndelegatedFromNode(PendingWithdrawal {
                         delegator: delegator2,
                         node: node1.address,
+                        undelegation_id: 2,
                         amount: U256::from(500000u64),
                         available_time: 900,
                     }),
@@ -1251,6 +1266,7 @@ mod tests {
             vec![WalletDiff::NodeExited(PendingWithdrawal {
                 delegator: delegator3,
                 node: node4.address,
+                undelegation_id: 0,
                 amount: U256::from(8000000u64),
                 available_time: 1500,
             })],
@@ -1335,7 +1351,7 @@ mod tests {
         assert_eq!(
             loaded_wallet2
                 .pending_undelegations
-                .get(&node1.address)
+                .get(&(node1.address, 2))
                 .unwrap()
                 .amount,
             U256::from(500000u64)
@@ -1373,6 +1389,7 @@ mod tests {
                     WalletDiff::UndelegatedFromNode(PendingWithdrawal {
                         delegator: delegator1,
                         node: node1.address,
+                        undelegation_id: 3,
                         amount: U256::from(1000000u64),
                         available_time: 1100,
                     }),
@@ -1381,6 +1398,7 @@ mod tests {
                     WalletDiff::NodeExited(PendingWithdrawal {
                         delegator: delegator1,
                         node: node2.address,
+                        undelegation_id: 0,
                         amount: U256::from(3000000u64),
                         available_time: 1200,
                     }),
@@ -1396,6 +1414,7 @@ mod tests {
                     WalletDiff::NodeExited(PendingWithdrawal {
                         delegator: delegator2,
                         node: node2.address,
+                        undelegation_id: 0,
                         amount: U256::from(10000000u64),
                         available_time: 1200,
                     }),
@@ -1403,6 +1422,7 @@ mod tests {
                     WalletDiff::UndelegationWithdrawal(Withdrawal {
                         delegator: delegator2,
                         node: node1.address,
+                        undelegation_id: 2,
                         amount: U256::from(500000u64),
                     }),
                     // Delegator2 claims rewards
@@ -1416,6 +1436,7 @@ mod tests {
                     WalletDiff::NodeExitWithdrawal(Withdrawal {
                         delegator: delegator3,
                         node: node4.address,
+                        undelegation_id: 0,
                         amount: U256::from(8000000u64),
                     }),
                     // Delegator3 delegates to new node5
@@ -1500,7 +1521,7 @@ mod tests {
         assert_eq!(
             wallet1
                 .pending_undelegations
-                .get(&node1.address)
+                .get(&(node1.address, 3))
                 .unwrap()
                 .amount,
             U256::from(1000000u64)
@@ -1560,6 +1581,128 @@ mod tests {
         assert_eq!(wallet3.pending_undelegations.len(), 0);
         // NodeExitWithdrawal completed, so no more pending_exits
         assert_eq!(wallet3.pending_exits.len(), 0);
+    }
+
+    /// Two pending undelegations from the same node, distinguished by undelegation ID, survive a
+    /// save/load round trip and can be withdrawn independently.
+    #[test_log::test(tokio::test)]
+    async fn test_concurrent_pending_undelegations_same_node() {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        let options = PersistenceOptions {
+            path: db_path,
+            max_connections: 5,
+        };
+
+        let mut persistence = Persistence::new(&options).await.unwrap();
+
+        let node = make_node(1);
+        let delegator = Address::random();
+
+        persistence
+            .save_genesis(Snapshot::empty(block_snapshot(0)))
+            .await
+            .unwrap();
+
+        // Delegate, then undelegate twice from the same node in one block.
+        let wallet_diffs = [(
+            delegator,
+            vec![
+                WalletDiff::DelegatedToNode(Delegation {
+                    delegator,
+                    node: node.address,
+                    amount: U256::from(1000u64),
+                }),
+                WalletDiff::UndelegatedFromNode(PendingWithdrawal {
+                    delegator,
+                    node: node.address,
+                    undelegation_id: 7,
+                    amount: U256::from(400u64),
+                    available_time: 800,
+                }),
+                WalletDiff::UndelegatedFromNode(PendingWithdrawal {
+                    delegator,
+                    node: node.address,
+                    undelegation_id: 8,
+                    amount: U256::from(100u64),
+                    available_time: 900,
+                }),
+            ],
+        )]
+        .into_iter()
+        .collect();
+
+        persistence
+            .apply_updates(vec![Update {
+                block: block_snapshot(100),
+                node_set_diffs: vec![FullNodeSetDiff::NodeUpdate(Arc::new(node.clone()))],
+                wallet_diffs,
+            }])
+            .await
+            .unwrap();
+
+        let snapshot = persistence
+            .load_finalized_snapshot()
+            .await
+            .unwrap()
+            .unwrap();
+        let wallet = snapshot.wallets.get(&delegator).unwrap();
+        assert_eq!(
+            wallet.nodes.get(&node.address).unwrap().amount,
+            U256::from(500u64)
+        );
+        assert_eq!(wallet.pending_undelegations.len(), 2);
+        let first = wallet
+            .pending_undelegations
+            .get(&(node.address, 7))
+            .unwrap();
+        assert_eq!(first.amount, U256::from(400u64));
+        assert_eq!(first.available_time, 800);
+        let second = wallet
+            .pending_undelegations
+            .get(&(node.address, 8))
+            .unwrap();
+        assert_eq!(second.amount, U256::from(100u64));
+        assert_eq!(second.available_time, 900);
+
+        // Withdraw one of the two undelegations; only that one is removed.
+        let wallet_diffs = [(
+            delegator,
+            vec![WalletDiff::UndelegationWithdrawal(Withdrawal {
+                delegator,
+                node: node.address,
+                undelegation_id: 7,
+                amount: U256::from(400u64),
+            })],
+        )]
+        .into_iter()
+        .collect();
+
+        persistence
+            .apply_updates(vec![Update {
+                block: block_snapshot(101),
+                node_set_diffs: vec![],
+                wallet_diffs,
+            }])
+            .await
+            .unwrap();
+
+        let snapshot = persistence
+            .load_finalized_snapshot()
+            .await
+            .unwrap()
+            .unwrap();
+        let wallet = snapshot.wallets.get(&delegator).unwrap();
+        assert_eq!(wallet.pending_undelegations.len(), 1);
+        assert_eq!(
+            wallet
+                .pending_undelegations
+                .get(&(node.address, 8))
+                .unwrap()
+                .amount,
+            U256::from(100u64)
+        );
     }
 
     #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -151,6 +151,11 @@ pub struct PendingWithdrawal {
     /// The node which was previously delegated to, which stake is now being withdrawn.
     pub node: Address,
 
+    /// The ID the stake table contract assigned to the undelegation.
+    ///
+    /// 0 for V1 undelegations (which had no IDs) and for node exits.
+    pub undelegation_id: u64,
+
     /// The amount of stake pending withdrawal.
     pub amount: ESPTokenAmount,
 
@@ -168,6 +173,11 @@ pub struct Withdrawal {
 
     /// The node which was previously delegated to, which stake is now withdrawn.
     pub node: Address,
+
+    /// The ID of the undelegation that was claimed.
+    ///
+    /// 0 for V1 undelegations (which had no IDs) and for node exits.
+    pub undelegation_id: u64,
 
     /// The amount of stake.
     pub amount: ESPTokenAmount,


### PR DESCRIPTION
Pending undelegations were tracked per (delegator, node), so the code assumed at most one pending undelegation per validator, and two undelegations from the same validator would panic on the duplicate insert which would not happen as the contract does not support it but it is better to add support for undelegation id like the contract does